### PR TITLE
Fix compare() method

### DIFF
--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -92,6 +92,8 @@ which this geometry code can position independently.
 
    .. automethod:: inspect
 
+   .. automethod:: compare
+
    .. automethod:: data_coords_to_positions
 
 DSSC-1M
@@ -130,3 +132,5 @@ approximately half a pixel width from their true position.
    .. automethod:: output_array_for_position_fast
 
    .. automethod:: inspect
+
+   .. automethod:: compare

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(name="EXtra-geom",
           'test': [
               'pytest',
               'pytest-cov',
+              'coverage <5',  # Until nbval issue #129 is fixed
               'nbval',
           ]
       },


### PR DESCRIPTION
Fixes #3 

This also makes `.compare()` use `.inspect()`, so it draws the same kind of picture. And I moved it onto the base class, so now all detector types support comparing two geometries.

Here's an example image from the new compare method:

![image](https://user-images.githubusercontent.com/327925/70913643-b833e700-2016-11ea-85ab-8edfed633fcf.png)
