### PR TITLE
Correct magic number in 1M geometry code

### DIFF
--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -981,7 +981,7 @@ class LPD_1MGeometry(DetectorGeometryBase):
                 mod_offset = mod_grp['Position'][:2]
 
                 tiles = []
-                for T in range(1, cls.n_modules+1):
+                for T in range(1, cls.n_tiles_per_module+1):
                     corner_pos = np.zeros(3)
                     tile_offset = mod_grp['T{:02}/Position'.format(T)][:2]
                     corner_pos[:2] = quad_pos + mod_offset + tile_offset


### PR DESCRIPTION
If I understood the geometry code correctly, it is a coincidence that LPD has the same number of modules as the number of tiles per module.

There are a few other places using a magic number instead of the class attributes. If you think it make sense, I will correct them as well.