### PR TITLE
Add support for pnCCD detector layout

### DIFF
--- a/extra_geom/__init__.py
+++ b/extra_geom/__init__.py
@@ -36,7 +36,7 @@ program. If not, see <https://opensource.org/licenses/BSD-3-Clause>
 __version__ = "0.9.0"
 
 from .detectors import (AGIPD_1MGeometry, LPD_1MGeometry, DSSC_1MGeometry,
-                        JUNGFRAUGeometry)
+                        JUNGFRAUGeometry, PNCCDGeometry)
 
 __all__ = ['AGIPD_1MGeometry', 'LPD_1MGeometry', 'DSSC_1MGeometry',
-           'JUNGFRAUGeometry']
+           'JUNGFRAUGeometry', 'PNCCDGeometry']

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -182,13 +182,13 @@ class DetectorGeometryBase:
         """
         from matplotlib.collections import PatchCollection
         from matplotlib.patches import FancyArrow
-        
+
         coord_scale = 1 / self.pixel_size
         arrow_scale = scale * coord_scale
 
         # Draw this geometry first, using pixel units
         ax = self.inspect()
-        
+
         if len(self.modules) != len(other.modules):
             print("Geometry objects have different numbers of modules!")
         if any(len(mod_a) != len(mod_b) for (mod_a, mod_b) in zip(self.modules, other.modules)):
@@ -1494,3 +1494,149 @@ class JUNGFRAUGeometry(DetectorGeometryBase):
     def write_crystfel_geom(self, file_name):
 
         raise NotImplementedError
+
+
+class PNCCDGeometry(DetectorGeometryBase):
+    """Detector layout for pnCCD
+
+    The large-area, pn-junction Charge Coupled Device detector consists
+    of two movable modules with a single tile each.
+
+    In its default configuration, the complete detector frame is read
+    out and written to file as a single image, with the modules split
+    along the slow-scan dimension y. The public methods of this type
+    support both the combined image array as well as separated module
+    with expected_data_shape.
+    """
+
+    detector_type_name = 'PNCCD1MP'
+    pixel_size = 75e-6
+    frag_ss_pixels = 512
+    frag_fs_pixels = 1024
+    n_modules = 2
+    n_tiles_per_module = 1
+    expected_data_shape = (2, 512, 1024)
+
+    # Each module has a rectangular cutout around the intended beam
+    # position, i.e. at the bottom center of the top module (towards
+    # negative y) and the top center of the bottom module (towards
+    # positive y).
+    cutout_width = 60 * pixel_size
+    cutout_height = 22 * pixel_size
+
+    @staticmethod
+    def split_tiles(module_data):
+        return np.split(module_data, 1, axis=-2)
+
+    @classmethod
+    def _tile_slice(cls, tileno):
+        return np.s_[0:cls.frag_ss_pixels], np.s_[0:cls.frag_fs_pixels]
+
+    @classmethod
+    def _module_coords_to_tile(cls, slow_scan, fast_scan):
+        return 0, slow_scan, fast_scan
+
+    @classmethod
+    def from_relative_positions(cls, gap=4e-3, top_offset=(0.0, 0.0, 0.0),
+                                bottom_offset=(0.0, 0.0, 0.0)):
+        """Generate a pnCCD geometry from relative module positions.
+
+        The modules are assumed to be separated by the a gap centered
+        around the beam (at the origin) in x, y and z = 0, with an
+        optional offset applied to each module.
+
+        Parameters
+        ----------
+
+        gap: float
+          The gap between the detector modules centered around the beam,
+          4mm (~50 px) by default.
+
+        top_offset, bottom_offset: array_like of length 3
+          Optional offset (x, y, z) for each module relative to the
+          centered position.
+        """
+
+        top = np.array(top_offset) + np.array([
+            -cls.frag_fs_pixels // 2 * cls.pixel_size,
+            gap / 2 + cls.frag_ss_pixels * cls.pixel_size,
+            0.0
+        ])
+
+        bottom = np.array(bottom_offset) + np.array([
+            -cls.frag_fs_pixels // 2 * cls.pixel_size,
+            -gap / 2,
+            0.0
+        ])
+
+        return cls.from_absolute_positions(top, bottom)
+
+    @classmethod
+    def from_absolute_positions(cls, top, bottom):
+        """Generate a pnCCD geometry from absolute module positions.
+
+        Parameters
+        ----------
+
+        top, bottom: array_like of length 3
+          Absolute position (x, y, z) for the first pixel of each
+          module.
+        """
+
+        args = (np.array([0, -cls.pixel_size, 0]),
+                np.array([cls.pixel_size, 0, 0]),
+                cls.frag_ss_pixels, cls.frag_fs_pixels)
+
+        return cls([[GeometryFragment(np.array(top), *args)],
+                    [GeometryFragment(np.array(bottom), *args)]])
+
+    @classmethod
+    def _ensure_shape(cls, data):
+        """Ensure image data has the proper shape.
+
+        As a pnCCD frame is read out and saved as a single array, the
+        public interface of this geometry implementation supports
+        automatic reshaping to separated modules.
+        """
+
+        if data.shape[-2:] == (cls.n_modules * cls.frag_ss_pixels,
+                               cls.frag_fs_pixels):
+            data = data.reshape(*data.shape[:-2], cls.n_modules,
+                                cls.frag_ss_pixels, cls.frag_fs_pixels)
+
+        return data
+
+    def inspect(self, axis_units='px', frontview=True):
+        from matplotlib.patches import Rectangle
+        
+        ax = super().inspect(axis_units=axis_units, frontview=frontview)
+        scale = self._get_plot_scale_factor(axis_units)
+
+        # Add patches for each rectangular cutout.
+        cutout_width = self.cutout_width * scale
+        cutout_height = self.cutout_height * scale
+
+        patch_dims = (cutout_width, cutout_height)
+        patch_kwargs = dict(hatch='///', ec='red', fc='none')
+
+        top, bottom = self.modules[0][0], self.modules[1][0]
+
+        ax.add_patch(Rectangle(
+            (top.centre()[0] * scale - cutout_width/2,
+             top.corners()[2][1] * scale),
+            *patch_dims, **patch_kwargs))
+
+        ax.add_patch(Rectangle(
+            (bottom.centre()[0] * scale - cutout_width/2,
+             bottom.corners()[0][1] * scale - cutout_height),
+            *patch_dims, **patch_kwargs))
+
+        return ax
+
+    def position_modules_fast(self, data, *args, **kwargs):
+        return super().position_modules_fast(self._ensure_shape(data),
+                                             *args, **kwargs)
+
+    def plot_data_fast(self, data, *args, **kwargs):
+        return super().plot_data_fast(self._ensure_shape(data),
+                                      *args, **kwargs)


### PR DESCRIPTION
Hi there,
this PR adds the somewhat simple geometry of the pnCCD detector, currently available to users at the SQS instrument. Please see here for its specification: https://www.xfel.eu/facility/instruments/sqs/instrument/nqs_end_station/index_eng.html

As the detector consists of only two _parts_, I am not sure whether to treat it as two modules with one tile each or one module with two tiles. Thus, I've actually created a version for both, with this branch implementing the former configuration and [pnccd_geom_1m2t](/European-XFEL/EXtra-geom/tree/pnccd_geom_1m2t) the latter. Note that the data for this detector is always read-out in one matrix for the complete frame, i.e. both _parts_ are concatenated. The public methods of `DetectorGeometryBase` are overriden to support this data format.

Personally, I find the 2m1t version expresses the separation more explicit, as it is visible in the data shape and not somewhat hidden behind the tile support. If the separation would ever become more complicated than simple reshaping however, this machinery would definitely be worthwhile to use. In the end, both versions are comparably simple, so I'd like to go with the version that fits the original design of EXtra-geom the most.
As a small side note, the scientists typically refer to it as modules rather than tiles.

EDIT: Please find a sample image for testing at /gpfs/exfel/data/scratch/schmidtp/pnccd_example.h5

PS: Not planning to skip on tests, but I'd really like to first get this in for the upcoming beamtime.