### PR TITLE
Reduce overhead for assembling images

### DIFF
--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -1055,10 +1055,15 @@ class LPD_1MGeometry(DetectorGeometryBase):
 
     @staticmethod
     def split_tiles(module_data):
-        half1, half2 = np.split(module_data, 2, axis=-1)
-        # Tiles 1-8 (half1) are numbered top to bottom, whereas the array
-        # starts at the bottom. So we reverse their order after splitting.
-        return np.split(half1, 8, axis=-2)[::-1] + np.split(half2, 8, axis=-2)
+        # This slicing is faster than using np.split()
+        return [
+            # Tiles 1-8 numbered top to bottom. Data starts at bottom, so
+            # count backwards through them.
+            module_data[..., y-32:y, :128] for y in range(256, 0, -32)
+        ] + [
+            # Tiles 9-16 numbered bottom to top.
+            module_data[..., y:y+32, 128:] for y in range(0, 256, 32)
+        ]
 
     @classmethod
     def _tile_slice(cls, tileno):
@@ -1282,7 +1287,8 @@ class DSSC_1MGeometry(DetectorGeometryBase):
     @staticmethod
     def split_tiles(module_data):
         # Split into 2 tiles along the fast-scan axis
-        return np.split(module_data, 2, axis=-1)
+        # This simple slicing is faster than np.split().
+        return [module_data[..., :256], module_data[..., 256:]]
 
     def plot_data_fast(self,
                        data, *,
@@ -1481,8 +1487,12 @@ class JUNGFRAUGeometry(DetectorGeometryBase):
 
     @staticmethod
     def split_tiles(module_data):
-        row1, row2 = np.split(module_data, 2, axis=-2)
-        return np.split(row1, 4, axis=-1) + np.split(row2, 4, axis=-1)
+        # 2 rows of 4 ASICs each. This slicing is faster than np.split().
+        return [
+            module_data[..., :256, x:x+256] for x in range(0, 1024, 256)
+        ] + [
+            module_data[..., 256:, x:x+256] for x in range(0, 1024, 256)
+        ]
 
     @classmethod
     def _tile_slice(cls, tileno):
@@ -1534,7 +1544,7 @@ class PNCCDGeometry(DetectorGeometryBase):
 
     @staticmethod
     def split_tiles(module_data):
-        return np.split(module_data, 1, axis=-2)
+        return [module_data]
 
     @classmethod
     def _tile_slice(cls, tileno):

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -800,7 +800,8 @@ class AGIPD_1MGeometry(DetectorGeometryBase):
     @staticmethod
     def split_tiles(module_data):
         # Split into 8 tiles along the slow-scan axis
-        return np.split(module_data, 8, axis=-2)
+        # This simple slicing is faster than np.split().
+        return [module_data[..., s:s+64, :] for s in range(0, 512, 64)]
 
     @classmethod
     def _tile_slice(cls, tileno):

--- a/extra_geom/snapped.py
+++ b/extra_geom/snapped.py
@@ -100,8 +100,7 @@ class SnappedGeometry:
         for i, module in enumerate(self.modules):
             mod_data = data[..., i, :, :]
             tiles_data = self.geom.split_tiles(mod_data)
-            for j, tile in enumerate(module):
-                tile_data = tiles_data[j]
+            for tile, tile_data in zip(module, tiles_data):
                 y, x = tile.corner_idx
                 h, w = tile.pixel_dims
                 out[..., y : y + h, x : x + w] = tile.transform(tile_data)

--- a/extra_geom/snapped.py
+++ b/extra_geom/snapped.py
@@ -6,6 +6,7 @@ extra_geom.detectors.
 """
 
 from copy import copy
+from itertools import chain
 import numpy as np
 
 
@@ -40,7 +41,7 @@ class GridGeometryFragment:
                 min(ss_order, 0) * self.ss_pixels,
                 min(fs_order, 0) * self.fs_pixels
             ])
-            self.pixel_dims = np.array([self.ss_pixels, self.fs_pixels])
+            self.pixel_dims = (self.ss_pixels, self.fs_pixels)
         else:
             # Fast scan is y : Transpose so fast scan -> x and then flip
             fs_order = fs_vec[0]
@@ -50,9 +51,13 @@ class GridGeometryFragment:
                 min(fs_order, 0) * self.fs_pixels,
                 min(ss_order, 0) * self.ss_pixels
             ])
-            self.pixel_dims = np.array([self.fs_pixels, self.ss_pixels])
-        self.corner_idx = corner_pos + corner_shift
-        self.opp_corner_idx = self.corner_idx + self.pixel_dims
+            self.pixel_dims = (self.fs_pixels, self.ss_pixels)
+        self.corner_idx = tuple(corner_pos + corner_shift)
+
+    def offset(self, y_x) -> 'GridGeometryFragment':
+        new = copy(self)
+        new.corner_idx = tuple(np.array(self.corner_idx) + y_x)
+        return new
 
 
 class SnappedGeometry:
@@ -62,10 +67,17 @@ class SnappedGeometry:
     Numpy array; this does not match the (x, y, z) coordinates in the more
     precise geometry above.
     """
-    def __init__(self, modules, geom):
+    def __init__(self, modules, geom, centre):
         self.modules = modules
         self.geom = geom
-        self.size_yx, self.centre = self._get_dimensions()
+        self.centre = centre
+
+        # The fragments here are already shifted so corner_idx starts from 0 in
+        # each dim, so the max outer edges define the output image size.
+        self.size_yx = tuple(np.max([
+            np.array(frag.corner_idx) + np.array(frag.pixel_dims)
+            for frag in chain(*modules)
+        ], axis=0))
 
     def make_output_array(self, extra_shape=(), dtype=np.float32):
         """Make an output array for self.position_modules()
@@ -90,32 +102,11 @@ class SnappedGeometry:
             tiles_data = self.geom.split_tiles(mod_data)
             for j, tile in enumerate(module):
                 tile_data = tiles_data[j]
-                # Offset by centre to make all coordinates positive
-                y, x = tile.corner_idx + self.centre
+                y, x = tile.corner_idx
                 h, w = tile.pixel_dims
                 out[..., y : y + h, x : x + w] = tile.transform(tile_data)
 
         return out, self.centre
-
-    def _get_dimensions(self):
-        """Calculate appropriate array dimensions for assembling data.
-
-        Returns (size_y, size_x), (centre_y, centre_x)
-        """
-        corners = []
-        for module in self.modules:
-            for tile in module:
-                corners.append(tile.corner_idx)
-                corners.append(tile.opp_corner_idx)
-        corners = np.stack(corners)
-
-        # Find extremes
-        min_yx = corners.min(axis=0)
-        max_yx = corners.max(axis=0)
-
-        size = max_yx - min_yx
-        centre = -min_yx
-        return tuple(size), centre
 
     def plot_data(self,
                   modules_data, *,

--- a/extra_geom/tests/test_geometry_old.py
+++ b/extra_geom/tests/test_geometry_old.py
@@ -16,7 +16,7 @@ quadpos = [(-11.4, -299), (11.5, -8), (-254.5, 16), (-278.5, -275)]
 
 
 def test_inspect():
-    with h5py.File(pjoin(tests_dir, 'lpd_mar_18.h5')) as f:
+    with h5py.File(pjoin(tests_dir, 'lpd_mar_18.h5'), 'r') as f:
         geom = LPDGeometry.from_h5_file_and_quad_positions(f, quadpos)
 
     # Smoketest
@@ -25,7 +25,7 @@ def test_inspect():
 
 
 def test_position_all_modules():
-    with h5py.File(pjoin(tests_dir, 'lpd_mar_18.h5')) as f:
+    with h5py.File(pjoin(tests_dir, 'lpd_mar_18.h5'), 'r') as f:
         geom = LPDGeometry.from_h5_file_and_quad_positions(f, quadpos)
 
     stacked_data = np.zeros((16, 256, 256))


### PR DESCRIPTION
In two areas:

1. Apply the centre offset (moving the origin from the centre to the corner) when making the snapped geometry, instead of leaving it until we assemble an image. This assumes you make a geometry once and assemble many images with it.
2. `numpy.split()` seems to be surprisingly costly to call - replacing it with list comprehensions and slicing makes `split_tiles()` up to an order of magnitude faster.

This makes most difference for assembling single images, and for detectors with lots of tiles. I see roughly a 35% speedup on a single image for LPD, 25% for AGIPD, and about 10% for DSSC.