### PR TITLE
Parallel image assembly

### DIFF
--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -333,7 +333,7 @@ class DetectorGeometryBase:
         return self._snapped().make_output_array(extra_shape=extra_shape,
                                                  dtype=dtype)
 
-    def position_modules_fast(self, data, out=None):
+    def position_modules_fast(self, data, out=None, threadpool=None):
         """Assemble data from this detector according to where the pixels are.
 
         This approximates the geometry to align all pixels to a 2D grid.
@@ -353,6 +353,11 @@ class DetectorGeometryBase:
           Parts of the array not covered by detector tiles are not overwritten.
           In general, you can reuse an output array if you are assembling
           similar pulses or pulse trains with the same geometry.
+        threadpool : concurrent.futures.ThreadPoolExecutor, optional
+          If passed, parallelise copying data into the output image.
+          By default, data for different tiles are copied serially.
+          For a single 1 MPx image, the default appears to be faster, but for
+          assembling a stack of several images at once, multithreading can help.
 
         Returns
         -------

--- a/extra_geom/tests/test_agipd_geometry.py
+++ b/extra_geom/tests/test_agipd_geometry.py
@@ -1,5 +1,5 @@
-
 from cfelpyutils.crystfel_utils import load_crystfel_geometry
+from concurrent.futures import ThreadPoolExecutor
 from itertools import product
 from matplotlib.axes import Axes
 import numpy as np
@@ -38,6 +38,11 @@ def test_snap_assemble_data():
     check_result(out, centre)
     assert img.dtype == out.dtype == np.float32
 
+    # Assemble in parallel
+    stacked_data = np.zeros((16, 512, 128))
+    with ThreadPoolExecutor(max_workers=2) as tpool:
+        img, centre = geom.position_modules_fast(stacked_data, threadpool=tpool)
+        check_result(img, centre)
 
 def test_write_read_crystfel_file(tmpdir):
     geom = AGIPD_1MGeometry.from_quad_positions(


### PR DESCRIPTION
The default is still serial. My tests suggest it's still quicker to assembling a single (AGIPD) image in serial: I guess the overheads of distributing the work outweigh the benefit of copying small amounts of memory in parallel. The benefit comes when you have a stack of images: the parallel code draws level by about 10 MB, and with 1.4 GB we can get more than an order of magnitude speedup.

This is based on threads, not processes, because the workers need to write to a single destination array. So we're relying on numpy releasing the GIL while copying data. In principle it could also be done with processes if you ensured that both the source and the destination arrays were in shared memory, but I haven't tried to tackle that.

I went for passing a threadpool in so you can reuse a threadpool. In practice, it appears to be so quick to create & tear down threads that this doesn't really matter, but I'm inclined to leave it that way anyway. You could also pass a process pool in if you want to experiment with shared memory, though I'm not documenting such possibilities.

