### PR TITLE
Methods to retrieve quadrant positions and write XFEL HDF5 geometry files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
+  - 3.8
   - 3.7
   - 3.6
-  - 3.5
 
 env:
   global:

--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -41,6 +41,8 @@ but this geometry code works with a position for each tile.
 
    .. automethod:: from_crystfel_geom
 
+   .. automethod:: quad_positions
+
    .. automethod:: write_crystfel_geom
 
    .. automethod:: get_pixel_positions
@@ -81,6 +83,10 @@ which this geometry code can position independently.
    .. automethod:: from_h5_file_and_quad_positions
 
    .. automethod:: from_crystfel_geom
+
+   .. automethod:: quad_positions
+
+   .. automethod:: to_h5_file_and_quad_positions
 
    .. automethod:: write_crystfel_geom
 
@@ -127,6 +133,10 @@ approximately half a pixel width from their true position.
 .. autoclass:: DSSC_1MGeometry
 
    .. automethod:: from_h5_file_and_quad_positions
+
+   .. automethod:: quad_positions
+
+   .. automethod:: to_h5_file_and_quad_positions
 
    .. automethod:: get_pixel_positions
 

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -1024,6 +1024,92 @@ class LPD_1MGeometry(DetectorGeometryBase):
 
         return cls(modules, filename=path)
 
+    def to_h5_file_and_quad_positions(self, path):
+        """Write this geometry to an XFEL HDF5 format geometry file
+
+        The quadrant positions are not stored in the file, so they are returned
+        separately. These and the numbers in the file are in millimetres.
+
+        The file and quadrant positions produced by this method are compatible
+        with :meth:`from_h5_file_and_quad_positions`.
+        """
+
+        quad_pos = []
+
+        for q in range(4):
+            quad_fragmts_corners = []
+            for mod in self.modules[q * 4: (q + 1) * 4]:
+                quad_fragmts_corners.extend(f.corners() for f in mod)
+
+            quad_points_xy = np.concatenate(quad_fragmts_corners)[:, :2]
+            quad_pos.append(quad_points_xy.max(axis=0))
+
+        quad_pos = np.stack(quad_pos)
+
+        module_offsets = []
+        tile_offsets = []
+
+        for m, module in enumerate(self.modules):
+            tile_positions = np.stack([f.corners().max(axis=0)[:2] for f in module])
+            module_position = tile_positions.max(axis=0)
+            tile_offsets.append(tile_positions - module_position)
+            module_offsets.append(module_position - quad_pos[m // 4])
+
+        with h5py.File(path, 'w') as hf:
+            for m in range(16):
+                Q, M = (m // 4) + 1, (m % 4) + 1
+                mod_grp = hf.create_group(f'Q{Q}/M{M}')
+                mod_grp['Position'] = module_offsets[m] * 1000  # m -> mm
+
+                for t in range(self.n_tiles_per_module):
+                    T = t + 1
+                    mod_grp[f'T{T:02}/Position'] = tile_offsets[m][t] * 1000  # m -> mm
+
+        return quad_pos * 1000  # m -> mm
+
+    def quad_positions(self, h5_file=None):
+        """Get the positions of the 4 quadrants
+
+        Quadrant positions are returned as (x, y) coordinates in millimetres.
+        Their meaning is as in :meth:`from_h5_file_and_quad_positions`.
+
+        To use the returned positions with an existing XFEL HDF5 geometry file,
+        the path to that file should be passed in. In that case, the offsets of
+        M4 T16 in each quadrant are read from the file to calculate a suitable
+        quadrant position. The geometry in the file is not checked against this
+        geometry object at all.
+        """
+        positions = np.zeros((4, 2), dtype=np.float64)
+
+        if h5_file is None:
+            for q in range(4):
+                quad_fragmts_corners = []
+                for mod in self.modules[q * 4: (q + 1) * 4]:
+                    quad_fragmts_corners.extend(f.corners() for f in mod)
+
+                quad_points_xy = np.concatenate(quad_fragmts_corners)[:, :2]
+                positions[q] = quad_points_xy.max(axis=0) * 1000  # m -> mm
+        else:
+            with h5py.File(h5_file, 'r') as f:
+                for q in range(4):
+                    # XFEL HDF5 geometry files for LPD record the position of
+                    # the high-x, high-y corner of each tile. Instead of
+                    # identifying which corner this is, we'll just take a
+                    # maximum over all 4 corners.
+                    # This assumes the tile is axis-aligned - for now, the XFEL
+                    # geometry format has no way to express rotation anyway.
+                    m4t16 = self.modules[(q * 4) + 3][15]
+                    m4t16_max_corner = m4t16.corners().max(axis=0)
+
+                    mod_grp = f[f'Q{q + 1}/M4']
+                    mod_offset = mod_grp['Position'][:2]
+                    tile_offset = mod_grp['T16/Position'][:2]
+
+                    tile_pos = m4t16_max_corner[:2] * 1000  # m (xyz) -> mm (xy)
+                    positions[q] = tile_pos - tile_offset - mod_offset
+
+        return positions
+
     def inspect(self, axis_units='px', frontview=True):
         """Plot the 2D layout of this detector geometry.
 

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -1199,8 +1199,8 @@ class DSSC_1MGeometry(DetectorGeometryBase):
         path : str
           Path of an EuXFEL format (HDF5) geometry file for DSSC.
         positions : list of 2-tuples
-          (x, y) coordinates of the last corner (the one by module 4) of each
-          quadrant.
+          (x, y) coordinates of the corner of each quadrant (the one with lowest
+          x and y coordinates).
         unit : float, optional
           The conversion factor to put the coordinates into metres.
           The default 1e-3 means the numbers are in millimetres.

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -694,6 +694,16 @@ class AGIPD_1MGeometry(DetectorGeometryBase):
                 ))
         return cls(modules)
 
+    def quad_positions(self):
+        """Retrieve the coordinates of the first pixel in each quadrant
+
+        The coordinates returned are 2D and in pixel units, compatible with
+        :meth:`from_quad_positions`.
+        """
+        return np.array([
+            self.modules[q * 4][0].corner_pos[:2] for q in range(4)
+        ]) / self.pixel_size
+
     def inspect(self, axis_units='px', frontview=True):
         """Plot the 2D layout of this detector geometry.
 

--- a/extra_geom/tests/test_agipd_geometry.py
+++ b/extra_geom/tests/test_agipd_geometry.py
@@ -99,6 +99,13 @@ def test_write_read_crystfel_file_2d(tmpdir):
     assert p3a7['max_fs'] == 127
 
 
+def test_quad_positions():
+    quad_pos = [(-525, 625), (-550, -10), (520, -160), (542.5, 475)]
+    geom = AGIPD_1MGeometry.from_quad_positions(quad_pos)
+
+    np.testing.assert_allclose(geom.quad_positions(), quad_pos)
+
+
 def test_inspect():
     geom = AGIPD_1MGeometry.from_quad_positions(
         quad_pos=[(-525, 625), (-550, -10), (520, -160), (542.5, 475)]

--- a/extra_geom/tests/test_dssc_geometry.py
+++ b/extra_geom/tests/test_dssc_geometry.py
@@ -86,3 +86,22 @@ def test_read_write_xfel_file(tmpdir):
 
     loaded = DSSC_1MGeometry.from_h5_file_and_quad_positions(path, quad_pos_out)
     assert_geom_close(loaded, geom)
+
+
+def test_quad_positions_with_file():
+    geom = DSSC_1MGeometry.from_h5_file_and_quad_positions(
+        sample_xfel_geom, QUAD_POS
+    )
+    quad_pos_out = geom.quad_positions(sample_xfel_geom)
+
+    np.testing.assert_allclose(quad_pos_out, QUAD_POS)
+
+
+def test_quad_positions_no_file():
+    geom = DSSC_1MGeometry.from_h5_file_and_quad_positions(
+        sample_xfel_geom, QUAD_POS
+    )
+    # Smoketest - the results without passing a file in aren't usable yet
+    quad_pos_out = geom.quad_positions()
+
+    assert quad_pos_out.shape == (4, 2)

--- a/extra_geom/tests/test_dssc_geometry.py
+++ b/extra_geom/tests/test_dssc_geometry.py
@@ -2,8 +2,10 @@ import h5py
 from matplotlib.axes import Axes
 import numpy as np
 from os.path import abspath, dirname, join as pjoin
+from testpath import assert_isfile
 
 from extra_geom import DSSC_1MGeometry
+from .utils import assert_geom_close
 
 tests_dir = dirname(abspath(__file__))
 sample_xfel_geom = pjoin(tests_dir, 'dssc_geo_june19.h5')
@@ -71,3 +73,16 @@ def test_get_pixel_positions():
 
     # Odd-numbered rows in Q1 & Q2 should have 0.5 pixel higher x than the even.
     np.testing.assert_allclose(px[0, 1::2, 0] - px[0, 0::2, 0], 236e-6/2)
+
+
+def test_read_write_xfel_file(tmpdir):
+    geom = DSSC_1MGeometry.from_h5_file_and_quad_positions(
+        sample_xfel_geom, QUAD_POS
+    )
+    path = str(tmpdir / 'dssc_geom.h5')
+    quad_pos_out = geom.to_h5_file_and_quad_positions(path)
+
+    assert_isfile(path)
+
+    loaded = DSSC_1MGeometry.from_h5_file_and_quad_positions(path, quad_pos_out)
+    assert_geom_close(loaded, geom)

--- a/extra_geom/tests/test_lpd_geometry.py
+++ b/extra_geom/tests/test_lpd_geometry.py
@@ -4,9 +4,11 @@ import h5py
 from matplotlib.axes import Axes
 import numpy as np
 from os.path import abspath, dirname, join as pjoin
+from testpath import assert_isfile
 
 from extra_geom import LPD_1MGeometry
 from extra_geom.detectors import invert_xfel_lpd_geom
+from .utils import assert_geom_close
 
 tests_dir = dirname(abspath(__file__))
 
@@ -46,6 +48,35 @@ def test_write_read_crystfel_file(tmpdir):
     assert geom_dict['rigid_groups']['p0'] == quad_gr0[:16]
     assert geom_dict['rigid_groups']['p3'] == quad_gr0[-16:]
     assert geom_dict['rigid_groups']['q0'] == quad_gr0
+
+
+def test_read_write_xfel_file(tmpdir):
+    quad_pos = [(11.4, 299), (-11.5, 8), (254.5, -16), (278.5, 275)]
+    geom = LPD_1MGeometry.from_quad_positions(quad_pos)
+    path = str(tmpdir / 'lpd_geom.h5')
+    quad_pos_out = geom.to_h5_file_and_quad_positions(path)
+
+    np.testing.assert_allclose(quad_pos_out, quad_pos)
+    assert_isfile(path)
+
+    loaded = LPD_1MGeometry.from_h5_file_and_quad_positions(path, quad_pos_out)
+    assert_geom_close(loaded, geom)
+
+
+def test_quad_positions_with_file():
+    path = pjoin(tests_dir, 'lpd_mar_18.h5')
+    quad_pos = [(11.4, 299), (-11.5, 8), (254.5, -16), (278.5, 275)]
+    geom = LPD_1MGeometry.from_h5_file_and_quad_positions(path, quad_pos)
+
+    np.testing.assert_allclose(geom.quad_positions(path), quad_pos)
+
+
+def test_quad_positions_no_file():
+    quad_pos = [(11.4, 299), (-11.5, 8), (254.5, -16), (278.5, 275)]
+    geom = LPD_1MGeometry.from_quad_positions(quad_pos)
+
+    np.testing.assert_allclose(geom.quad_positions(), quad_pos)
+
 
 def test_inspect():
     geom = LPD_1MGeometry.from_quad_positions(

--- a/extra_geom/tests/utils.py
+++ b/extra_geom/tests/utils.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+def all_tiles(geom):
+    for mod in geom.modules:
+        yield from mod
+
+def tile_positions(geom):
+    return np.stack([t.corner_pos for t in all_tiles(geom)])
+
+def tile_vectors(geom):
+    return np.stack([(t.ss_vec, t.fs_vec) for t in all_tiles(geom)])
+
+def assert_geom_close(g1, g2):
+    assert len(g1.modules) == len(g2.modules)
+    assert {len(m) for m in g1.modules} == {len(m) for m in g2.modules}
+
+    np.testing.assert_allclose(tile_positions(g1), tile_positions(g2))
+    np.testing.assert_allclose(tile_vectors(g1), tile_vectors(g2))

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(name="EXtra-geom",
               'pytest-cov',
               'coverage',
               'nbval',
+              'testpath',
           ]
       },
       python_requires='>=3.5',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(name="EXtra-geom",
               'testpath',
           ]
       },
-      python_requires='>=3.5',
+      python_requires='>=3.6',
       classifiers=[
           'Development Status :: 3 - Alpha',
           'Environment :: Console',


### PR DESCRIPTION
More ways of getting geometry out. These are closely linked because the XFEL geometry files store offsets from quadrant positions. So to get quadrant positions compatible with an XFEL file, you need to either create both together, or read the file when creating quadrant positions. This will be used in geoAssembler.

I'm aiming for consistency within detector classes more than betweeen them, so quadrant positions for LPD & DSSC are returned in mm (like XFEL geometry files), but quadrant positions for AGIPD are in pixel units (like CrystFEL geometry files). Not ideal, but I figure that it's more important to easily roundtrip each geometry to/from files & quadrant positions than it is to compare geometries for different detectors.

I started writing an internal abstraction over the XFEL HDF5 geometry format, but the generalisation was adding much more code than it was saving, so I abandoned it for now.

Closes #18
Closes #20