### PR TITLE
Assemble data around the centre of an array

### DIFF
--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -55,6 +55,8 @@ but this geometry code works with a position for each tile.
 
    .. automethod:: output_array_for_position_fast
 
+   .. automethod:: position_modules_symmetric
+
    .. automethod:: position_modules_interpolate
 
    .. automethod:: inspect
@@ -94,6 +96,8 @@ but this geometry code works with a position for each tile.
    .. automethod:: position_modules_fast
 
    .. automethod:: output_array_for_position_fast
+
+   .. automethod:: position_modules_symmetric
 
    .. automethod:: inspect
 
@@ -137,6 +141,8 @@ which this geometry code can position independently.
    .. automethod:: position_modules_fast
 
    .. automethod:: output_array_for_position_fast
+
+   .. automethod:: position_modules_symmetric
 
    .. automethod:: inspect
 

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -369,11 +369,43 @@ class DetectorGeometryBase:
         centre : ndarray
           (y, x) pixel location of the detector centre in this geometry.
         """
-        return self._snapped().position_modules(data, out=out)
+        return self._snapped().position_modules(data, out=out, threadpool=threadpool)
 
     def position_all_modules(self, data, out=None):
         """Deprecated alias for :meth:`position_modules_fast`"""
         return self.position_modules_fast(data, out=out)
+
+    def position_modules_symmetric(self, data, out=None, threadpool=None):
+        """Assemble data with the centre in the middle of the output array.
+
+        The assembly process is the same as :meth:`position_modules_fast`,
+        aligning each module to a single pixel grid. But this makes the output
+        array symmetric, with the centre at (height // 2, width // 2).
+
+        Parameters
+        ----------
+
+        data : ndarray
+          The last three dimensions should match the modules, then the
+          slow scan and fast scan pixel dimensions.
+        out : ndarray, optional
+          An output array to assemble the image into. By default, a new
+          array is created at the minimum size to allow symmetric assembly.
+          If an array is passed in, its last two dimensions must be at least
+          this size.
+        threadpool : concurrent.futures.ThreadPoolExecutor, optional
+          If passed, parallelise copying data into the output image.
+          See :meth:`position_modules_fast` for details.
+
+        Returns
+        -------
+        out : ndarray
+          Array with one dimension fewer than the input.
+          The last two dimensions represent pixel y and x in the detector space.
+        """
+        return self._snapped().position_modules_symmetric(
+            data, out=out, threadpool=threadpool
+        )
 
     def plot_data_fast(self,
                        data, *,

--- a/extra_geom/tests/test_agipd_geometry.py
+++ b/extra_geom/tests/test_agipd_geometry.py
@@ -62,6 +62,10 @@ def test_assemble_symmetric():
     # Smoketest assembling into suitable output array
     geom.position_modules_symmetric(stacked_data, out=img)
 
+    with pytest.raises(ValueError):
+        # Output array not big enough
+        geom.position_modules_symmetric(stacked_data, out=img[:-1, :-1])
+
 
 def test_write_read_crystfel_file(tmpdir):
     geom = AGIPD_1MGeometry.from_quad_positions(

--- a/extra_geom/tests/test_agipd_geometry.py
+++ b/extra_geom/tests/test_agipd_geometry.py
@@ -44,6 +44,22 @@ def test_snap_assemble_data():
         img, centre = geom.position_modules_fast(stacked_data, threadpool=tpool)
         check_result(img, centre)
 
+
+def test_assemble_symmetric():
+    geom = AGIPD_1MGeometry.from_quad_positions(
+        quad_pos=[(-525, 625), (-550, -10), (520, -160), (542.5, 475)]
+    )
+    print("2 centre", geom._snapped().centre * 2)
+
+    stacked_data = np.zeros((16, 512, 128))
+    img = geom.position_modules_symmetric(stacked_data)
+
+    assert img.shape == (1262, 1100)
+    assert np.isnan(img[0, 0])
+    assert np.isnan(img[img.shape[0] // 2, img.shape[1] // 2])
+    assert img[50, 50] == 0
+
+
 def test_write_read_crystfel_file(tmpdir):
     geom = AGIPD_1MGeometry.from_quad_positions(
         quad_pos=[(-525, 625), (-550, -10), (520, -160), (542.5, 475)]

--- a/extra_geom/tests/test_agipd_geometry.py
+++ b/extra_geom/tests/test_agipd_geometry.py
@@ -59,6 +59,9 @@ def test_assemble_symmetric():
     assert np.isnan(img[img.shape[0] // 2, img.shape[1] // 2])
     assert img[50, 50] == 0
 
+    # Smoketest assembling into suitable output array
+    geom.position_modules_symmetric(stacked_data, out=img)
+
 
 def test_write_read_crystfel_file(tmpdir):
     geom = AGIPD_1MGeometry.from_quad_positions(


### PR DESCRIPTION
As described in #19, this adds a method to assemble data so that the centre of the detector is centred within the output array, i.e. at `height // 2, width // 2`. I've called this `position_modules_symmetric` for now, but I'd welcome suggestions for a clearer name.

I haven't made a corresponding method to create an empty output array (like `output_array_for_position_fast`), though it's easy enough to add if it's useful. Code that wants to reuse an output array can always get one by assembling an empty stack of data first.