### PR TITLE
Dependabot integration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/.github/dependabot/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot/constraints.txt
+++ b/.github/dependabot/constraints.txt
@@ -1,0 +1,12 @@
+cfelpyutils==1.0.0
+cycler==0.10.0
+future==0.18.2
+h5py==3.1.0
+kiwisolver==1.3.1
+matplotlib==3.3.3
+numpy==1.19.4
+Pillow==8.0.1
+pyparsing==2.4.7
+python-dateutil==2.8.1
+scipy==1.5.4
+six==1.15.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,12 +26,12 @@ jobs:
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('**/setup.py') }}
+        key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('**/setup.py') }}-${{ hashFiles('.github/dependabot/constraints.txt') }}
 
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install -e ".[test]"
+        python3 -m pip install -e ".[test]" --constraint .github/dependabot/constraints.txt
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Same as for extra-data: added `.github/dependabot/constraints.txt` which is used to constrain package versions installed during the test, and it is used by dependabot to trigger PRs when a dependency is updated. Also added python 3.9 to the test matrix.