### PR TITLE
FIX: Agipd500k module slow scan read orientation

### DIFF
--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -1016,15 +1016,16 @@ class AGIPD_500K2GGeometry(DetectorGeometryBase):
         module_height = cls.frag_fs_pixels * cls.pixel_size
         # In x, 64 px + gap between tiles (asics)
         tile_width = (cls.frag_ss_pixels + asic_gap_px) * cls.pixel_size
-        module_width = 8 * tile_width
+        module_width = 8 * tile_width - asic_gap_px * cls.pixel_size  # 8 tiles + 7 gaps
 
         # coordinates relative to the first pixel of the first module
         # detector's bottom-right corner
         ref = (
-            asic_gap_px * cls.pixel_size - module_width,      # x
+            - module_width,  # x
             - (3 * (cls.frag_fs_pixels + panel_gap[1]) * unit)  # y
         )
-        ref = (- (origin[0] * unit + ref[0]), - (origin[1] * unit + ref[1]))  # origin
+        # origin
+        ref = (- (origin[0] * unit + ref[0]), - (origin[1] * unit + ref[1]))
 
         modules = []
         for p in range(cls.n_modules):

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -1020,7 +1020,10 @@ class AGIPD_500K2GGeometry(DetectorGeometryBase):
 
         # coordinates relative to the first pixel of the first module
         # detector's bottom-right corner
-        ref = (0, - (3 * (cls.frag_fs_pixels + panel_gap[1]) * unit))  
+        ref = (
+            asic_gap_px * cls.pixel_size - module_width,      # x
+            - (3 * (cls.frag_fs_pixels + panel_gap[1]) * unit)  # y
+        )
         ref = (- (origin[0] * unit + ref[0]), - (origin[1] * unit + ref[1]))  # origin
 
         modules = []
@@ -1032,11 +1035,11 @@ class AGIPD_500K2GGeometry(DetectorGeometryBase):
             modules.append(tiles)
 
             for a in range(cls.n_tiles_per_module):
-                corner_x = panel_corner_x + a * tile_width
+                corner_x = panel_corner_x - a * tile_width
 
                 tiles.append(GeometryFragment(
                     corner_pos=np.array([corner_x, panel_corner_y, 0.]),
-                    ss_vec=np.array([1, 0, 0]) * unit,
+                    ss_vec=np.array([-1, 0, 0]) * unit,
                     fs_vec=np.array([0, 1, 0]) * unit,
                     ss_pixels=cls.frag_ss_pixels,
                     fs_pixels=cls.frag_fs_pixels,

--- a/extra_geom/tests/test_agipd500k2g_geometry.py
+++ b/extra_geom/tests/test_agipd500k2g_geometry.py
@@ -152,6 +152,6 @@ def test_data_coords_to_positions():
     np.testing.assert_allclose(resz, 0)
     np.testing.assert_allclose(resy, 100 * geom.pixel_size)
 
-    assert (np.diff(resx) < 0).all()   # Monotonically increasing
+    assert (np.diff(resx) < 0).all()   # Monotonically decreasing
     np.testing.assert_allclose(resx[0], 526 * geom.pixel_size)
     assert -0.01 < resx[-1] < 0.01

--- a/extra_geom/tests/test_agipd500k2g_geometry.py
+++ b/extra_geom/tests/test_agipd500k2g_geometry.py
@@ -136,10 +136,10 @@ def test_get_pixel_positions():
     assert  0. < py.min() < 0.0002
 
 def test_data_coords_to_positions():
-    geom = AGIPD_500K2GGeometry.from_origin((512, -100))
+    geom = AGIPD_500K2GGeometry.from_origin((0, -100))
 
     module_no = np.full(8, fill_value=6, dtype=np.int16)
-    slow_scan = np.linspace(0, 512, num=8, dtype=np.float32)
+    slow_scan = np.linspace(0, 511, num=8, dtype=np.float32)
     fast_scan = np.zeros(8, dtype=np.float32)
 
     res = geom.data_coords_to_positions(module_no, slow_scan, fast_scan)
@@ -152,6 +152,6 @@ def test_data_coords_to_positions():
     np.testing.assert_allclose(resz, 0)
     np.testing.assert_allclose(resy, 100 * geom.pixel_size)
 
-    assert (np.diff(resx) > 0).all()   # Monotonically increasing
-    np.testing.assert_allclose(resx[0], -512 * geom.pixel_size)
+    assert (np.diff(resx) < 0).all()   # Monotonically increasing
+    np.testing.assert_allclose(resx[0], 526 * geom.pixel_size)
     assert -0.01 < resx[-1] < 0.01

--- a/extra_geom/tests/test_agipd500k2g_geometry.py
+++ b/extra_geom/tests/test_agipd500k2g_geometry.py
@@ -11,7 +11,7 @@ from extra_geom import AGIPD_500K2GGeometry
 def test_snap_assemble_data():
 
     def check_result(img, centre):
-        assert img.shape == (602, 1070)
+        assert img.shape == (602, 1068)
         assert tuple(centre) == (-100, -100)
         assert np.isnan(img[0, 535])
         assert img[50, 50] == 0


### PR DESCRIPTION
closes #40 

![inspect](https://user-images.githubusercontent.com/32831491/102259738-c8272500-3f0f-11eb-9829-6945a094baeb.png)

![assemble](https://user-images.githubusercontent.com/32831491/102259777-d412e700-3f0f-11eb-9575-64c6b675e077.png)

@cydanil 