### PR TITLE
Read & write CrystFEL format geometry for JUNGFRAU

### DIFF
--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -222,6 +222,10 @@ Each module is further subdivided into 8 sensor tiles.
 
    .. automethod:: from_module_positions
 
+   .. automethod:: from_crystfel_geom
+
+   .. automethod:: write_crystfel_geom
+
    .. automethod:: get_pixel_positions
 
    .. automethod:: to_distortion_array

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -82,6 +82,7 @@ class DetectorGeometryBase:
     pixel_size = 0.0
     frag_ss_pixels = 0
     frag_fs_pixels = 0
+    n_quads = 0
     n_modules = 0
     n_tiles_per_module = 0
     expected_data_shape = (0, 0, 0)
@@ -285,7 +286,7 @@ class DetectorGeometryBase:
     def write_crystfel_geom(self, filename, *,
                             data_path='/entry_1/instrument_1/detector_1/data',
                             mask_path=None, dims=('frame', 'modno', 'ss', 'fs'),
-                            nquads=4, adu_per_ev=None, clen=None,
+                            nquads=None, adu_per_ev=None, clen=None,
                             photon_energy=None):
         """Write this geometry to a CrystFEL format (.geom) geometry file.
 
@@ -313,6 +314,8 @@ class DetectorGeometryBase:
         photon_energy : float
             Beam wave length in eV
         """
+        if nquads is None:
+            nquads = self.n_quads
         write_crystfel_geom(
             self, filename, data_path=data_path, mask_path=mask_path, dims=dims,
             nquads=nquads, adu_per_ev=adu_per_ev, clen=clen,
@@ -777,6 +780,7 @@ class AGIPD_1MGeometry(DetectorGeometryBase):
     frag_ss_pixels = 64
     frag_fs_pixels = 128
     expected_data_shape = (16, 512, 128)
+    n_quads = 4
     n_modules = 16
     n_tiles_per_module = 8
 
@@ -1185,6 +1189,7 @@ class LPD_1MGeometry(DetectorGeometryBase):
     pixel_size = 5e-4  # 5e-4 metres == 0.5 mm
     frag_ss_pixels = 32
     frag_fs_pixels = 128
+    n_quads = 4
     n_modules = 16
     n_tiles_per_module = 16
     expected_data_shape = (16, 256, 256)
@@ -1564,6 +1569,7 @@ class DSSC_1MGeometry(DetectorGeometryBase):
     pixel_size = 236e-6
     frag_ss_pixels = 128
     frag_fs_pixels = 256
+    n_quads = 4
     n_modules = 16
     n_tiles_per_module = 2
     expected_data_shape = (16, 128, 512)
@@ -2001,10 +2007,6 @@ class JUNGFRAUGeometry(DetectorGeometryBase):
         ss_slice = slice(tile_ss_offset, tile_ss_offset + cls.frag_ss_pixels)
         fs_slice = slice(tile_fs_offset, tile_fs_offset + cls.frag_fs_pixels)
         return ss_slice, fs_slice
-
-    def write_crystfel_geom(self, file_name):
-
-        raise NotImplementedError
 
 
 class PNCCDGeometry(DetectorGeometryBase):

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -1892,7 +1892,7 @@ class JUNGFRAUGeometry(DetectorGeometryBase):
           for each offset to the global origin. Coordinates are in pixel units
           by default.
 
-          These offsets are positions for the bottom, beam-left corner of each
+          These offsets are positions for the bottom, beam-right corner of each
           module, regardless of its orientation.
 
         orientations: iterable of tuples

--- a/extra_geom/tests/test_jungfrau_geometry.py
+++ b/extra_geom/tests/test_jungfrau_geometry.py
@@ -1,0 +1,54 @@
+
+from cfelpyutils.crystfel_utils import load_crystfel_geometry
+import numpy as np
+
+from extra_geom import JUNGFRAUGeometry
+from .utils import assert_geom_close
+
+def jf4m_geometry():
+    x_start, y_start = 1125, 1078
+    mod_width = (256 * 4) + (2 * 3)
+    mod_height = (256 * 2) + 2
+
+    module_pos = [  #
+        (x_start - mod_width, y_start - mod_height - (i * (mod_height + 33)))
+        for i in range(4)
+    ] + [
+        (-x_start, -y_start + (i * (mod_height + 33))) for i in range(4)
+    ]
+    orientations = [(-1, -1) for _ in range(4)] + [(1, 1) for _ in range(4)]
+
+    return JUNGFRAUGeometry.from_module_positions(module_pos, orientations=orientations)
+
+
+def test_write_read_crystfel_file(tmpdir):
+    geom = jf4m_geometry()
+    path = str(tmpdir / 'test.geom')
+    geom.write_crystfel_geom(filename=path, photon_energy=9000,
+                             adu_per_ev=0.0042, clen=0.101)
+
+    loaded = JUNGFRAUGeometry.from_crystfel_geom(path)
+    assert_geom_close(loaded, geom)
+
+    # Load the geometry file with cfelpyutils and test the rigid groups
+    geom_dict = load_crystfel_geometry(path)
+    assert geom_dict['panels']['p0a0']['res'] == 1 / 75e-6
+    p3a7 = geom_dict['panels']['p3a7']
+    assert p3a7['min_ss'] == 256
+    assert p3a7['max_ss'] == 511
+    assert p3a7['min_fs'] == 768
+    assert p3a7['max_fs'] == 1023
+
+
+def test_get_pixel_positions():
+    geom = jf4m_geometry()
+
+    pixelpos = geom.get_pixel_positions()
+    assert pixelpos.shape == (8, 512, 1024, 3)
+    px = pixelpos[..., 0]
+    py = pixelpos[..., 1]
+
+    assert -0.09 < px.min() < -0.07
+    assert 0.09 > px.max() > 0.07
+    assert -0.09 < py.min() < -0.07
+    assert 0.09 > py.max() > 0.07


### PR DESCRIPTION
This also makes reading CrystFEL format geometry more robust (I hope) by not relying on the `p0a0` panel names (which are arbitrary, as far as CrystFEL is concerned). Instead, we identify which piece of the input data each panel description refers to, by the 'data coordinate' (module number, slow-scan, fast-scan) of its first pixel.

![Screenshot from 2021-02-15 17-54-17](https://user-images.githubusercontent.com/327925/107979700-ef08e280-6fb6-11eb-8548-5a7c9e474ec3.png)