### PR TITLE
Allow passing xarray DataArray object to position_modules_fast()

### DIFF
--- a/.github/dependabot/constraints.txt
+++ b/.github/dependabot/constraints.txt
@@ -10,3 +10,4 @@ pyparsing==2.4.7
 python-dateutil==2.8.1
 scipy<1.7.0
 six==1.15.0
+xarray<=0.17.0

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -382,9 +382,10 @@ class DetectorGeometryBase:
         Parameters
         ----------
 
-        data : ndarray
+        data : ndarray or xarray.DataArray
           The last three dimensions should match the modules, then the
-          slow scan and fast scan pixel dimensions.
+          slow scan and fast scan pixel dimensions. If an xarray labelled array
+          is given, it must have a 'module' dimension.
         out : ndarray, optional
           An output array to assemble the image into. By default, a new
           array is allocated. Use :meth:`output_array_for_position_fast` to
@@ -424,9 +425,10 @@ class DetectorGeometryBase:
         Parameters
         ----------
 
-        data : ndarray
+        data : ndarray or xarray.DataArray
           The last three dimensions should match the modules, then the
-          slow scan and fast scan pixel dimensions.
+          slow scan and fast scan pixel dimensions. If an xarray labelled array
+          is given, it must have a 'module' dimension.
         out : ndarray, optional
           An output array to assemble the image into. By default, a new
           array is created at the minimum size to allow symmetric assembly.

--- a/extra_geom/snapped.py
+++ b/extra_geom/snapped.py
@@ -4,7 +4,7 @@ This is useful to copy data from multiple modules into a single image array.
 This module is not a public API: it's used internally by the classes in
 extra_geom.detectors.
 """
-
+import sys
 from copy import copy
 from itertools import chain
 import numpy as np
@@ -88,19 +88,45 @@ class SnappedGeometry:
     def position_modules(self, data, out=None, threadpool=None):
         """Implementation for position_modules_fast
         """
-        assert data.shape[-3:] == self.geom.expected_data_shape
-        if out is None:
-            out = self.make_output_array(data.shape[:-3], data.dtype)
+        nmod = self.geom.expected_data_shape[0]
+        if isinstance_no_import(data, 'xarray', 'DataArray'):
+            # Input is an xarray labelled array
+            modnos = data.coords.get('module')
+            if modnos is None:
+                raise ValueError(
+                    "xarray arrays should have a dimension named 'module'"
+                )
+            modnos = modnos.values  # xarray -> numpy
+            min_mod, max_mod = modnos.min(), modnos.max()
+            if min_mod < 0 or max_mod >= nmod:
+                raise ValueError(
+                    f"module number labels should be in the range 0-{nmod-1} "
+                    f"(found {min_mod}-{max_mod})"
+                )
+            assert data.shape[-2:] == self.geom.expected_data_shape[-2:]
+
+            mod_dim_ix = data.dims.index('module')
+            extra_shape = data.shape[:mod_dim_ix] + data.shape[mod_dim_ix+1:-2]
+            get_mod_data = lambda i: data.sel(module=i).values
         else:
-            assert out.shape == data.shape[:-3] + self.size_yx
+            # Input is a numpy array (or similar unlabelled array)
+            assert data.shape[-3:] == self.geom.expected_data_shape
+            modnos = range(nmod)
+            extra_shape = data.shape[:-3]
+            get_mod_data = np.moveaxis(data, -3, 0).__getitem__
+
+        if out is None:
+            out = self.make_output_array(extra_shape, data.dtype)
+        else:
+            assert out.shape == extra_shape + self.size_yx
             if not np.can_cast(data.dtype, out.dtype, casting='safe'):
                 raise TypeError("{} cannot be safely cast to {}".
                                 format(data.dtype, out.dtype))
 
         copy_pairs = []
-        for i, module in enumerate(self.modules):
-            mod_data = data[..., i, :, :]
-            tiles_data = self.geom.split_tiles(mod_data)
+        for modno in modnos:
+            module = self.modules[modno]
+            tiles_data = self.geom.split_tiles(get_mod_data(modno))
             for tile, tile_data in zip(module, tiles_data):
                 y, x = tile.corner_idx
                 h, w = tile.pixel_dims
@@ -199,3 +225,12 @@ class SnappedGeometry:
         ax.hlines(0, -cross_size, +cross_size, colors='w', linewidths=1)
         ax.vlines(0, -cross_size, +cross_size, colors='w', linewidths=1)
         return ax
+
+
+def isinstance_no_import(obj, mod: str, cls: str):
+    """Check if isinstance(obj, mod.cls) without loading mod"""
+    m = sys.modules.get(mod)
+    if m is None:
+        return False
+
+    return isinstance(obj, getattr(m, cls))

--- a/extra_geom/snapped.py
+++ b/extra_geom/snapped.py
@@ -4,10 +4,10 @@ This is useful to copy data from multiple modules into a single image array.
 This module is not a public API: it's used internally by the classes in
 extra_geom.detectors.
 """
-import sys
 from copy import copy
 from itertools import chain
 import numpy as np
+import sys
 
 
 class GridGeometryFragment:

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(name="EXtra-geom",
               'coverage',
               'nbval',
               'testpath',
+              'xarray',
           ]
       },
       python_requires='>=3.6',


### PR DESCRIPTION
Labelled arrays are expected to have a `module` dimension with labels starting from index 0. Closes #38.

cc @daviddoji 