### PR TITLE
Use np.zeros() to make output array for integer data

### DIFF
--- a/extra_geom/snapped.py
+++ b/extra_geom/snapped.py
@@ -84,7 +84,12 @@ class SnappedGeometry:
         """Make an output array for self.position_modules()
         """
         shape = extra_shape + self.size_yx
-        return np.full(shape, np.nan, dtype=dtype)
+        if np.issubdtype(dtype, np.floating):
+            return np.full(shape, np.nan, dtype=dtype)
+
+        # zeros() is much faster than full() with 0 - part of the cost is just
+        # deferred until we fill it, but it's probably still advantageous.
+        return np.zeros(shape, dtype=dtype)
 
     def position_modules(self, data, out=None, threadpool=None):
         """Implementation for position_modules_fast


### PR DESCRIPTION
We've found elsewhere that filling integer data with NaN doesn't always convert it to 0. `np.zeros()` is also much faster than `np.full(..., 0)` - largely because of virtual memory tricks which defer some of the cost until you write to it, but it's probably still a useful optimisation for big arrays. Here's a blog post with more background about these memory tricks: https://vorpus.org/blog/why-does-calloc-exist/

cc @daviddoji 