### PR TITLE
Make scipy an optional dependency

### DIFF
--- a/.github/dependabot/constraints.txt
+++ b/.github/dependabot/constraints.txt
@@ -8,6 +8,5 @@ numpy<1.22.0
 Pillow==8.3.1
 pyparsing==2.4.7
 python-dateutil==2.8.2
-scipy<1.8.0
 six==1.16.0
 xarray<0.20.0

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ to use in other environments with Python 3.6 or later:
 
 If you get a permissions error, add the `--user` flag to that command.
 
+There is one optional feature: install `extra_geom[interpolate]` to use
+the `position_modules_interpolate` method (slow).
+
+
 
 Contributing
 ===========

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,9 @@ to use in other environments with Python 3.6 or later::
 
 If you get a permissions error, add the ``--user`` flag to that command.
 
+There is one optional feature: install ``extra_geom[interpolate]`` to use
+the :meth:`~.position_modules_interpolate` method (slow).
+
 Documentation contents
 ----------------------
 

--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,9 @@ setup(name="EXtra-geom",
           'h5py>=2.7.1',
           'matplotlib',
           'numpy',
-          'scipy',
       ],
       extras_require={
+          'interpolate': ['scipy'],
           'docs': [
               'sphinx',
               'nbsphinx',


### PR DESCRIPTION
This is only used for the (very slow) `position_modules_interpolate()` method, which I suspect ~no-one is using (because we'd surely get complaints about how slow it is if people were).

cc @philsmt 