### PR TITLE
Store & use quadrant positions in EuXFEL HDF5 format geometry files

### DIFF
--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -132,6 +132,8 @@ which this geometry code can position independently.
 
    .. automethod:: from_h5_file_and_quad_positions
 
+   .. automethod:: from_h5_file
+
    .. automethod:: from_crystfel_geom
 
    .. automethod:: offset
@@ -187,6 +189,8 @@ approximately half a pixel width from their true position.
 .. autoclass:: DSSC_1MGeometry
 
    .. automethod:: from_h5_file_and_quad_positions
+
+   .. automethod:: from_h5_file
 
    .. automethod:: offset
 

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -808,6 +808,10 @@ class LPD_1MGeometry(DetectorGeometryBase):
             module_offsets.append(module_position - quad_pos[m // 4])
 
         with h5py.File(path, 'w') as hf:
+            for q in range(4):
+                Q = q + 1
+                hf[f'Q{Q}/Position'] = quad_pos[q] * 1000  # m -> mm
+
             for m in range(16):
                 Q, M = (m // 4) + 1, (m % 4) + 1
                 mod_grp = hf.create_group(f'Q{Q}/M{M}')
@@ -1126,6 +1130,10 @@ class DSSC_1MGeometry(DetectorGeometryBase):
             module_offsets.append(module_position - quad_pos[m // 4])
 
         with h5py.File(path, 'w') as hf:
+            for q in range(4):
+                Q = q + 1
+                hf[f'Q{Q}/Position'] = quad_pos[q] * 1000  # m -> mm
+
             for m in range(16):
                 Q, M = (m // 4) + 1, (m % 4) + 1
                 mod_grp = hf.create_group(f'Q{Q}/M{M}')

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -717,10 +717,10 @@ class LPD_1MGeometry(DetectorGeometryBase):
     def from_h5_file_and_quad_positions(cls, path, positions, unit=1e-3):
         """Load an LPD-1M geometry from an XFEL HDF5 format geometry file
 
-        The quadrant positions are not stored in the file, and must be provided
-        separately. By default, both the quadrant positions and the positions
+        By default, both the quadrant positions and the positions
         in the file are measured in millimetres; the unit parameter controls
-        this.
+        this. The passed positions override quadrant positions from the file, if
+        it contains them: see :meth:`from_h5_file` to use them.
 
         The origin of the coordinates is in the centre of the detector.
         Coordinates increase upwards and to the left (looking along the beam).
@@ -778,6 +778,18 @@ class LPD_1MGeometry(DetectorGeometryBase):
 
     @classmethod
     def from_h5_file(cls, path):
+        """Load an LPD-1M geometry from an XFEL HDF5 format geometry file
+
+        This requires a file containing quadrant positions, which not all
+        XFEL geometry files do. Use :meth:`from_h5_file_and_quad_positions` to
+        load a file which does not have them.
+
+        Parameters
+        ----------
+
+        path : str
+          Path of an EuXFEL format (HDF5) geometry file for LPD.
+        """
         with h5py.File(path, 'r') as f:
             try:
                 quadpos = [f[f'Q{Q}/Position'][:2] for Q in range(1, 5)]
@@ -793,8 +805,8 @@ class LPD_1MGeometry(DetectorGeometryBase):
     def to_h5_file_and_quad_positions(self, path):
         """Write this geometry to an XFEL HDF5 format geometry file
 
-        The quadrant positions are not stored in the file, so they are returned
-        separately. These and the numbers in the file are in millimetres.
+        The quadrant positions are stored in the file, but also returned.
+        These and the numbers in the file are in millimetres.
 
         The file and quadrant positions produced by this method are compatible
         with :meth:`from_h5_file_and_quad_positions`.
@@ -1036,9 +1048,10 @@ class DSSC_1MGeometry(DetectorGeometryBase):
     def from_h5_file_and_quad_positions(cls, path, positions, unit=1e-3):
         """Load a DSSC geometry from an XFEL HDF5 format geometry file
 
-        The quadrant positions are not stored in the file, and must be provided
-        separately. The position given should refer to the bottom right (looking
-        along the beam) corner of the quadrant.
+        The position given should refer to the bottom right (looking
+        along the beam) corner of the quadrant. The passed positions override
+        quadrant positions from the file, if it contains them:
+        see :meth:`from_h5_file` to use them.
 
         By default, both the quadrant positions and the positions
         in the file are measured in millimetres; the unit parameter controls
@@ -1114,6 +1127,18 @@ class DSSC_1MGeometry(DetectorGeometryBase):
 
     @classmethod
     def from_h5_file(cls, path):
+        """Load a DSSC geometry from an XFEL HDF5 format geometry file
+
+        This requires a file containing quadrant positions, which not all
+        XFEL geometry files do. Use :meth:`from_h5_file_and_quad_positions` to
+        load a file which does not have them.
+
+        Parameters
+        ----------
+
+        path : str
+          Path of an EuXFEL format (HDF5) geometry file for DSSC.
+        """
         with h5py.File(path, 'r') as f:
             try:
                 quadpos = [f[f'Q{Q}/Position'][:2] for Q in range(1, 5)]
@@ -1129,8 +1154,8 @@ class DSSC_1MGeometry(DetectorGeometryBase):
     def to_h5_file_and_quad_positions(self, path):
         """Write this geometry to an XFEL HDF5 format geometry file
 
-        The quadrant positions are not stored in the file, so they are returned
-        separately. These and the numbers in the file are in millimetres.
+        The quadrant positions are stored in the file, but also returned.
+        These and the numbers in the file are in millimetres.
 
         The file and quadrant positions produced by this method are compatible
         with :meth:`from_h5_file_and_quad_positions`.

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -776,6 +776,20 @@ class LPD_1MGeometry(DetectorGeometryBase):
 
         return cls(modules, filename=path)
 
+    @classmethod
+    def from_h5_file(cls, path):
+        with h5py.File(path, 'r') as f:
+            try:
+                quadpos = [f[f'Q{Q}/Position'][:2] for Q in range(1, 5)]
+            except KeyError:
+                raise ValueError(
+                    "This HDF5 geometry file does not include quadrant positions. "
+                    "You can use it with separately specified positions by "
+                    "calling from_h5_file_and_quad_positions()"
+                )
+
+        return cls.from_h5_file_and_quad_positions(path, quadpos)
+
     def to_h5_file_and_quad_positions(self, path):
         """Write this geometry to an XFEL HDF5 format geometry file
 
@@ -1097,6 +1111,20 @@ class DSSC_1MGeometry(DetectorGeometryBase):
                 modules.append(tiles)
 
         return cls(modules, filename=path)
+
+    @classmethod
+    def from_h5_file(cls, path):
+        with h5py.File(path, 'r') as f:
+            try:
+                quadpos = [f[f'Q{Q}/Position'][:2] for Q in range(1, 5)]
+            except KeyError:
+                raise ValueError(
+                    "This HDF5 geometry file does not include quadrant positions. "
+                    "You can use it with separately specified positions by "
+                    "calling from_h5_file_and_quad_positions()"
+                )
+
+        return cls.from_h5_file_and_quad_positions(path, quadpos)
 
     def to_h5_file_and_quad_positions(self, path):
         """Write this geometry to an XFEL HDF5 format geometry file

--- a/extra_geom/tests/test_dssc_geometry.py
+++ b/extra_geom/tests/test_dssc_geometry.py
@@ -78,7 +78,7 @@ def test_get_pixel_positions():
     np.testing.assert_allclose(px[0, 1::2, 0] - px[0, 0::2, 0], 236e-6/2)
 
 
-def test_read_write_xfel_file(tmpdir):
+def test_read_write_xfel_file_quadpos(tmpdir):
     geom = DSSC_1MGeometry.from_h5_file_and_quad_positions(
         sample_xfel_geom, QUAD_POS
     )
@@ -88,6 +88,19 @@ def test_read_write_xfel_file(tmpdir):
     assert_isfile(path)
 
     loaded = DSSC_1MGeometry.from_h5_file_and_quad_positions(path, quad_pos_out)
+    assert_geom_close(loaded, geom)
+
+
+def test_read_write_xfel_file(tmpdir):
+    geom = DSSC_1MGeometry.from_h5_file_and_quad_positions(
+        sample_xfel_geom, QUAD_POS
+    )
+    path = str(tmpdir / 'dssc_geom.h5')
+    geom.to_h5_file_and_quad_positions(path)
+
+    assert_isfile(path)
+
+    loaded = DSSC_1MGeometry.from_h5_file(path)
     assert_geom_close(loaded, geom)
 
 

--- a/extra_geom/tests/test_lpd_geometry.py
+++ b/extra_geom/tests/test_lpd_geometry.py
@@ -53,7 +53,7 @@ def test_write_read_crystfel_file(tmpdir):
     assert geom_dict['rigid_groups']['q0'] == quad_gr0
 
 
-def test_read_write_xfel_file(tmpdir):
+def test_read_write_xfel_file_quadpos(tmpdir):
     quad_pos = [(11.4, 299), (-11.5, 8), (254.5, -16), (278.5, 275)]
     geom = LPD_1MGeometry.from_quad_positions(quad_pos)
     path = str(tmpdir / 'lpd_geom.h5')
@@ -63,6 +63,18 @@ def test_read_write_xfel_file(tmpdir):
     assert_isfile(path)
 
     loaded = LPD_1MGeometry.from_h5_file_and_quad_positions(path, quad_pos_out)
+    assert_geom_close(loaded, geom)
+
+
+def test_read_write_xfel_file(tmpdir):
+    quad_pos = [(11.4, 299), (-11.5, 8), (254.5, -16), (278.5, 275)]
+    geom = LPD_1MGeometry.from_quad_positions(quad_pos)
+    path = str(tmpdir / 'lpd_geom.h5')
+    geom.to_h5_file_and_quad_positions(path)
+
+    assert_isfile(path)
+
+    loaded = LPD_1MGeometry.from_h5_file(path)
     assert_geom_close(loaded, geom)
 
 


### PR DESCRIPTION
`to_h5_file_and_quad_positions` will also write quadrant positions into the file, in a similar format to the existing module & tile positions. There is a new class method `from_h5_file` to load such a geometry file without passing in quadrant positions separately.

Quadrant positions are relative to the centre of the detector (often the point where the beam passes through, but see #10). This is what EXtra-geom uses internally, inspired by CrystFEL geometry, but might be surprising for DET.

For now, this only applies to LPD & DSSC, as these are the only detectors where we've implemented reading & writing HDF5 files.

Closes #91.