### PR TITLE
Add geom.rotate()

### DIFF
--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -43,6 +43,8 @@ but this geometry code works with a position for each tile.
 
    .. automethod:: offset
 
+   .. automethod:: rotate
+
    .. automethod:: quad_positions
 
    .. automethod:: write_crystfel_geom
@@ -138,6 +140,8 @@ which this geometry code can position independently.
 
    .. automethod:: offset
 
+   .. automethod:: rotate
+
    .. automethod:: quad_positions
 
    .. automethod:: to_h5_file_and_quad_positions
@@ -195,6 +199,8 @@ approximately half a pixel width from their true position.
    .. automethod:: from_h5_file
 
    .. automethod:: offset
+
+   .. automethod:: rotate
 
    .. automethod:: quad_positions
 

--- a/extra_geom/base.py
+++ b/extra_geom/base.py
@@ -810,11 +810,11 @@ class DetectorGeometryBase:
         increasing looking toward the detector front plan, x increasing to
         the left, y increasing to the top. Positive rotations are clockwise.
 
-In other words:
+        In other words:
 
-- Positive x angles tilt the top edge of the detector backwards, away from the source
-- Positive y angles tilt the right-hand edge (looking along the beam) away from the source
-- Positive z angles turn the detector clockwise (looking along the beam)
+        - Positive x angles tilt the top edge of the detector backwards, away from the source
+        - Positive y angles tilt the right-hand edge (looking along the beam) away from the source
+        - Positive z angles turn the detector clockwise (looking along the beam)
 
         By default, this rotates all modules & tiles.
         Returns a new geometry object of the same type.

--- a/extra_geom/base.py
+++ b/extra_geom/base.py
@@ -799,7 +799,8 @@ class DetectorGeometryBase:
             ] for m, module in enumerate(self.modules)
         ])
 
-    def rotate(self, angles, center=None, modules=np.s_[:], tiles=np.s_[:]):
+    def rotate(self, angles, center=None, modules=np.s_[:], tiles=np.s_[:],
+               degrees=True):
         """Rotate around first pixel
 
         Parameters
@@ -819,6 +820,9 @@ class DetectorGeometryBase:
             Select modules to rotate; defaults to all modules.
         tiles: slice
             Select tiles to move within each module; defaults to all tiles.
+        degrees: bool
+            If True (default), angles are in degrees. If False, angles are in
+            radians.
         """
         rot = np.asarray(angles)
         if rot.shape[-1] != 3:
@@ -884,9 +888,12 @@ class DetectorGeometryBase:
             )
 
         @lru_cache()
-        def _rot(deg):
+        def _rot(rotations):
             # generate rotation matrix for the given angles
-            w, p, k = np.deg2rad(deg)
+            if degrees:
+                w, p, k = np.deg2rad(rotations)
+            else:
+                w, p, k = rotations
 
             rot_x = np.array([[1, 0, 0],
                               [0, np.cos(w), -np.sin(w)],

--- a/extra_geom/base.py
+++ b/extra_geom/base.py
@@ -801,7 +801,24 @@ class DetectorGeometryBase:
 
     def rotate(self, angles, center=None, modules=np.s_[:], tiles=np.s_[:],
                degrees=True):
-        """Rotate around first pixel
+        """Rotate part or all of the detector, making a new geometry.
+
+        By default, this rotates all modules & tiles.
+        Returns a new geometry object of the same type.
+
+        ::
+
+            # Rotate the whole geometry by 90 degree in the xy plan
+            geom2 = geom.rotate((0, 0, 90))
+
+            # Move the tile 0 in the module 0 around its center by 90 degrees
+            geom2 = geom.rotate((0, 0, 90), modules=np.s_[:1], tiles=np.s_[:1])
+
+            # Rotate each module by a separate amount
+            rotate = np.zeros((16, 3))
+            rotate[5] = (3, 5, 1)  # x, y, z for individual modules
+            rotate[10] = (0, -2, 1)
+            geom2 = geom.rotate(rotate)
 
         Parameters
         ----------

--- a/extra_geom/base.py
+++ b/extra_geom/base.py
@@ -810,6 +810,12 @@ class DetectorGeometryBase:
         increasing looking toward the detector front plan, x increasing to
         the left, y increasing to the top. Positive rotations are clockwise.
 
+In other words:
+
+- Positive x angles tilt the top edge of the detector backwards, away from the source
+- Positive y angles tilt the right-hand edge (looking along the beam) away from the source
+- Positive z angles turn the detector clockwise (looking along the beam)
+
         By default, this rotates all modules & tiles.
         Returns a new geometry object of the same type.
 

--- a/extra_geom/base.py
+++ b/extra_geom/base.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from itertools import chain
 
 import numpy as np
@@ -53,6 +54,12 @@ class GeometryFragment:
     def offset(self, shift):
         pos = self.corner_pos + shift
         return type(self)(pos, self.ss_vec, self.fs_vec, self.ss_pixels, self.fs_pixels)
+
+    def rotate(self, angles, center):
+        ss_vec = self.ss_vec @ angles
+        fs_vec = self.fs_vec @ angles
+        pos = (self.corner_pos - center) @ angles + center
+        return type(self)(pos, ss_vec, fs_vec, self.ss_pixels, self.fs_pixels)
 
     def snap(self, px_shape):
         # Round positions and vectors to integers, drop z dimension
@@ -788,6 +795,114 @@ class DetectorGeometryBase:
         return cls([
             [
                 tile.offset(all_shifts[m, t])
+                for t, tile in enumerate(module)
+            ] for m, module in enumerate(self.modules)
+        ])
+
+    def rotate(self, angles, center=None, modules=np.s_[:], tiles=np.s_[:]):
+        """Rotate around first pixel
+
+        Parameters
+        ----------
+
+        angles: np.array or tuple
+            (x, y, z) rotations to apply in degree. Can be a single rotation
+            for all selected modules, a 2D array with a rotation per module, or
+            a 3D array with a rotation per tile (``arr[module, tile, xyz]``).
+        center: np.array or tuple
+            center of rotation. Shape must match angles.shape.
+            If set to None (default), the rotation center is set to:
+            * all modules: center of the detector
+            * selected modules: centers of modules
+            * selected tiles: centers of tiles
+        modules: slice
+            Select modules to rotate; defaults to all modules.
+        tiles: slice
+            Select tiles to move within each module; defaults to all tiles.
+        """
+        rot = np.asarray(angles)
+        if rot.shape[-1] != 3:
+            raise ValueError('Rotation angles must be 3d (x, y, z). '
+                             f'Last dimension was {rot.shape[-1]}')
+        if center is not None and np.asarray(center).shape != rot.shape:
+            raise ValueError('Rotation center must have same shape as angles')
+
+        ntiles = len(max((m for m in self.modules), key=len))
+        all_rot = np.zeros((len(self.modules), ntiles, 3), dtype=rot.dtype)
+        sel_rot = all_rot[modules, tiles]
+
+        refs = np.zeros((len(self.modules), ntiles, 3), dtype=np.float64)
+        sel_refs = refs[modules, tiles]
+
+        if center is None:
+            if rot.shape[:-1] == sel_rot.shape[:2] or tiles != np.s_[:]:
+                # Per-tile rotation
+                refs[modules, tiles] = np.array(
+                    [[t.centre() for t in m[tiles]]
+                    for m in self.modules[modules]]
+                )
+            elif rot.shape[:-1] == sel_rot.shape[:1] or modules != np.s_[:]:
+                # Per-module rotation
+                mods = []
+                for module in self.modules[modules]:
+                    center = np.mean([t.centre() for t in module], axis=0)
+                    mods.append(np.array([center for _ in module[tiles]]))
+                refs[modules, tiles] = np.array(mods)
+        else:
+            center = np.asarray(center)
+            if center.shape[:-1] == sel_refs.shape[:2]:
+                # Per-tile offsets
+                sel_refs[:] = center
+            elif center.shape[:-1] == sel_refs.shape[:1]:
+                # Per-module offsets - broadcast across tiles
+                sel_refs[:] = center[:, np.newaxis]
+            elif center.shape[:-1] == ():
+                # Single shift - broadcast across modules and tiles
+                sel_refs[:] = center
+            else:
+                raise ValueError(
+                    f"Got {center.shape[:-1]} coordinates. Expected either a "
+                    f"single coordinate (), a coordinate per module "
+                    f"{sel_refs.shape[:1]} or a coordinate per tile "
+                    f"{sel_refs.shape[:2]}"
+                )
+
+        if rot.shape[:-1] == sel_rot.shape[:2]:
+            # per-tile rotations
+            sel_rot[:] = rot
+        elif rot.shape[:-1] == sel_rot.shape[:1]:
+            # per-module rotations - broadcast across tiles
+            sel_rot[:] = rot[:, np.newaxis]
+        elif rot.shape[:-1] == ():
+            # single rotation - broadcast across modules and tiles
+            sel_rot[:] = rot
+        else:
+            raise ValueError(
+                f"Got {rot.shape[:-1]} coordinates. Expected either a single "
+                f"coordinate (), a coordinate per module {sel_rot.shape[:1]} "
+                f"or a coordinate per tile {sel_rot.shape[:2]}"
+            )
+
+        @lru_cache()
+        def _rot(deg):
+            # generate rotation matrix for the given angles
+            w, p, k = np.deg2rad(deg)
+
+            rot_x = np.array([[1, 0, 0],
+                              [0, np.cos(w), -np.sin(w)],
+                              [0, np.sin(w), np.cos(w)]])
+            rot_y = np.array([[np.cos(p), 0, np.sin(p)],
+                              [0, 1, 0],
+                              [-np.sin(p), 0, np.cos(p)]])
+            rot_z = np.array([[np.cos(k), -np.sin(k), 0],
+                              [np.sin(k), np.cos(k), 0],
+                              [0, 0, 1]])
+
+            return rot_x @ rot_y @ rot_z
+
+        return type(self)([
+            [
+                tile.rotate(_rot(tuple(all_rot[m, t])), refs[m, t])
                 for t, tile in enumerate(module)
             ] for m, module in enumerate(self.modules)
         ])

--- a/extra_geom/tests/test_lpd_geometry.py
+++ b/extra_geom/tests/test_lpd_geometry.py
@@ -152,15 +152,6 @@ def test_offset():
 def test_rotate():
     quad_pos = [(11.4, 299), (-11.5, 8), (254.5, -16), (278.5, 275)]
     geom = LPD_1MGeometry.from_quad_positions(quad_pos)
-    dy, dx = geom.output_array_for_position_fast().shape
-    print(dy, dx)
-    print(geom.position_all_modules(np.zeros((16, 256, 256))))
-
-    x0 = geom.modules[0][0].corner_pos[0]
-    y0 = geom.modules[0][0].corner_pos[1]
-    z0 = geom.modules[0][0].corner_pos[2]
-    y_orig = np.array([m[0].corner_pos[1] for m in geom.modules])
-    print(x0, y0, z0)
 
     # Uniform rotation for all modules, all tiles
     all_rotated = geom.rotate((90, 0, 0))
@@ -242,6 +233,14 @@ def test_rotate():
     # angles must be 3D
     with pytest.raises(ValueError):
         geom.rotate((1, 1))
+
+    # angles in radian
+    deg = geom.rotate((90, 0, 0), modules=np.s_[:1], tiles=np.s_[:1])
+    rad = geom.rotate((np.pi / 2, 0, 0), modules=np.s_[:1], tiles=np.s_[:1], degrees=False)
+    np.testing.assert_array_almost_equal(
+        deg.modules[1][1].corners(),
+        rad.modules[1][1].corners()
+    )
 
 
 def test_inspect():

--- a/extra_geom/tests/test_lpd_geometry.py
+++ b/extra_geom/tests/test_lpd_geometry.py
@@ -212,6 +212,24 @@ def test_rotate():
         )
 
     # set rotation center, per-det/mod/tile
+    rot = np.zeros((4, 16, 3), dtype=np.float64)
+    rot[:, 2, :] = (90, 0, 0)
+    center = np.zeros((4, 16, 3), dtype=np.float64)
+    center[0, 2, :] = geom.modules[8][2].centre()
+    center[1, 2, :] = geom.modules[9][2].centre()
+    center[2, 2, :] = geom.modules[10][2].centre()
+    center[3, 2, :] = geom.modules[11][2].centre()
+    q3_t2_rotated = geom.rotate(rot, center=center, modules=np.s_[8:12])
+    y = np.array([m[2].corner_pos[1] for m in q3_t2_rotated.modules[8:12]])
+    np.testing.assert_array_almost_equal(
+        y,
+        [
+            geom.modules[8][2].centre()[1],
+            geom.modules[9][2].centre()[1],
+            geom.modules[10][2].centre()[1],
+            geom.modules[11][2].centre()[1]
+        ]
+    )
 
     # Wrong number of modules
     with pytest.raises(ValueError):


### PR DESCRIPTION
For refining geometry, it's useful to be able to move elements at different levels - whole detector, quadrant, module or tile. EXtra-geom should provide methods to make this easy.

```python3
import numpy as np
from extra_geom import LPD_1MGeometry
%matplotlib notebook


quad_pos = [(11.4, 299), (-11.5, 8), (254.5, -16), (278.5, 275)]
geom = LPD_1MGeometry.from_quad_positions(quad_pos)

angles = np.zeros((16, 16, 3))
center = np.zeros((16, 16, 3))

angles[:4, ...] = (0, 0, -30)
center[:4, :, :] = np.mean(
    [t.centre() for m in geom.modules[:4] for t in m], axis=0)

for n, mod in enumerate(geom.modules[4:8], start=4):
    mod_centre = np.mean([t.centre() for t in mod], axis=0)
    angles[n, ...] = (0, 0, (-1)**n * n*-5)
    center[n, ...] = mod_centre

for m, mod in enumerate(geom.modules[8:12], start=8):
    for t, tile in enumerate(mod):
        angles[m, t] = (0, 0, -(m-7)*t)
        center[m, t, ...] = tile.centre()

for m, mod in enumerate(geom.modules[12:], start=12):
    for t, tile in enumerate(mod):
        angles[m, t] = (-(m-7)*t, 0, 0)
        center[m, t, ...] = tile.centre()

geom.rotate(angles, center).inspect()
```

![geom-rotate](https://user-images.githubusercontent.com/32831491/141442734-c01af9d4-99b7-488f-a242-899a0cc25726.png)