### PR TITLE
Method to plot data on hexagons for DSSC

### DIFF
--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -220,6 +220,8 @@ approximately half a pixel width from their true position.
 
    .. automethod:: plot_data
 
+   .. automethod:: plot_data_hexes
+
    .. automethod:: position_modules
 
    .. automethod:: output_array_for_position

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -1415,7 +1415,7 @@ class DSSC_1MGeometry(DetectorGeometryBase):
 
         collection = PolyCollection(
             [self._pixel_corners[::-1].T * self.pixel_size],
-            offsets=self.get_pixel_positions(centre=False)[..., :2].reshape(-1, 2),
+            offsets=px_offsets,
             transOffset=IdentityTransform(),
             offset_position="data",
             cmap=_cmap,

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -1405,11 +1405,12 @@ class DSSC_1MGeometry(DetectorGeometryBase):
         from matplotlib.cm import viridis
         from matplotlib.collections import PolyCollection
 
-        if module is None:
+        single_mod = module is not None
+        if single_mod:
+            assert data.shape == self.expected_data_shape[1:]
+        else:
             assert data.shape == self.expected_data_shape
             module = np.s_[:]
-        else:
-            assert data.shape == self.expected_data_shape[1:]
 
         px_offsets = self.get_pixel_positions(centre=False)[module, ..., :2]\
                          .reshape(-1, 2)
@@ -1424,7 +1425,9 @@ class DSSC_1MGeometry(DetectorGeometryBase):
         _cmap.set_bad('0.25', 1.0)
 
         if ax is None:
-            fig = plt.figure(figsize=figsize or (10, 10))
+            fig = plt.figure(figsize=figsize or (
+                (8, 4) if single_mod else (10, 10)
+            ))
             ax = fig.add_subplot(1, 1, 1)
 
         try:
@@ -1452,7 +1455,7 @@ class DSSC_1MGeometry(DetectorGeometryBase):
         if isinstance(colorbar, dict) or colorbar is True:
             if isinstance(colorbar, bool):
                 colorbar = {}
-            if not isinstance(module, slice):
+            if single_mod:
                 # With single module, horizontal colorbar uses space better
                 colorbar.setdefault('location', 'bottom')
             plt.colorbar(collection, ax=ax, **colorbar)

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -1426,7 +1426,7 @@ class DSSC_1MGeometry(DetectorGeometryBase):
 
         if ax is None:
             fig = plt.figure(figsize=figsize or (
-                (8, 4) if single_mod else (10, 10)
+                (8, 3) if single_mod else (10, 10)
             ))
             ax = fig.add_subplot(1, 1, 1)
 

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -1394,6 +1394,13 @@ class DSSC_1MGeometry(DetectorGeometryBase):
             self, data, *, frontview=True, ax=None, figsize=None, colorbar=False,
             module=None,
     ):
+        """Plot data from the detector showing hexagonal pixels
+
+        Most of the arguments are like those for :meth:`plot_data`. This method
+        is slower, but sometimes useful to look at small details. It can also
+        plot data for a single module, if you pass a suitable 2D array as *data*
+        and a module number as *module*.
+        """
         import matplotlib.pyplot as plt
         from matplotlib.cm import viridis
         from matplotlib.collections import PolyCollection

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -1452,7 +1452,7 @@ class DSSC_1MGeometry(DetectorGeometryBase):
         if isinstance(colorbar, dict) or colorbar is True:
             if isinstance(colorbar, bool):
                 colorbar = {}
-            if module is not None:
+            if not isinstance(module, slice):
                 # With single module, horizontal colorbar uses space better
                 colorbar.setdefault('location', 'bottom')
             plt.colorbar(collection, ax=ax, **colorbar)

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -1417,7 +1417,8 @@ class DSSC_1MGeometry(DetectorGeometryBase):
             [self._pixel_corners[::-1].T * self.pixel_size],
             offsets=self.get_pixel_positions(centre=False)[..., :2].reshape(-1, 2),
             transOffset=IdentityTransform(),
-            offset_position="data"
+            offset_position="data",
+            cmap=_cmap,
         )
         collection.set_array(data.ravel())
 

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -1455,9 +1455,9 @@ class DSSC_1MGeometry(DetectorGeometryBase):
         if isinstance(colorbar, dict) or colorbar is True:
             if isinstance(colorbar, bool):
                 colorbar = {}
-            if single_mod:
+            if single_mod and ('location' not in colorbar):
                 # With single module, horizontal colorbar uses space better
-                colorbar.setdefault('location', 'bottom')
+                colorbar.setdefault('orientation', 'horizontal')
             plt.colorbar(collection, ax=ax, **colorbar)
 
         ax.set_xlabel('metres')

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -1392,12 +1392,20 @@ class DSSC_1MGeometry(DetectorGeometryBase):
 
     def plot_data_hexes(
             self, data, *, frontview=True, ax=None, figsize=None, colorbar=False,
+            module=None,
     ):
         import matplotlib.pyplot as plt
         from matplotlib.cm import viridis
         from matplotlib.collections import PolyCollection
 
-        px_offsets = self.get_pixel_positions(centre=False)[..., :2].reshape(-1, 2)
+        if module is None:
+            assert data.shape == self.expected_data_shape
+            module = np.s_[:]
+        else:
+            assert data.shape == self.expected_data_shape[1:]
+
+        px_offsets = self.get_pixel_positions(centre=False)[module, ..., :2]\
+                         .reshape(-1, 2)
 
         min_x, min_y = px_offsets.min(axis=0)
         max_x, max_y = px_offsets.max(axis=0)
@@ -1445,6 +1453,7 @@ class DSSC_1MGeometry(DetectorGeometryBase):
         margin = 3 * self.pixel_size
         ax.set_xlim(min_x - margin, max_x + margin)
         ax.set_ylim(min_y - margin, max_y - margin)
+        ax.set_aspect(1)
         if frontview:
             ax.invert_xaxis()
 

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -1396,7 +1396,6 @@ class DSSC_1MGeometry(DetectorGeometryBase):
         import matplotlib.pyplot as plt
         from matplotlib.cm import viridis
         from matplotlib.collections import PolyCollection
-        from matplotlib.transforms import IdentityTransform
 
         px_offsets = self.get_pixel_positions(centre=False)[..., :2].reshape(-1, 2)
 
@@ -1413,12 +1412,22 @@ class DSSC_1MGeometry(DetectorGeometryBase):
             fig = plt.figure(figsize=figsize or (10, 10))
             ax = fig.add_subplot(1, 1, 1)
 
+        try:
+            # matplotlib 3.3.0 onwards
+            from matplotlib.transforms import AffineDeltaTransform
+            tfm_kwargs = {'transOffset': AffineDeltaTransform(ax.transData)}
+        except ImportError:
+            # Works Up to (& excluding) matplotlib 3.5.0 - offset_position removed
+            from matplotlib.transforms import IdentityTransform
+            tfm_kwargs = {
+                'transOffset': IdentityTransform(), 'offset_position': 'data'
+            }
+
         collection = PolyCollection(
             [self._pixel_corners[::-1].T * self.pixel_size],
             offsets=px_offsets,
-            transOffset=IdentityTransform(),
-            offset_position="data",
             cmap=_cmap,
+            **tfm_kwargs
         )
         collection.set_array(data.ravel())
 

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -1428,7 +1428,7 @@ class DSSC_1MGeometry(DetectorGeometryBase):
         if isinstance(colorbar, dict) or colorbar is True:
             if isinstance(colorbar, bool):
                 colorbar = {}
-            colorbar = plt.colorbar(collection, ax=ax, **colorbar)
+            plt.colorbar(collection, ax=ax, **colorbar)
 
         ax.set_xlabel('metres')
         ax.set_ylabel('metres')

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -1452,6 +1452,9 @@ class DSSC_1MGeometry(DetectorGeometryBase):
         if isinstance(colorbar, dict) or colorbar is True:
             if isinstance(colorbar, bool):
                 colorbar = {}
+            if module is not None:
+                # With single module, horizontal colorbar uses space better
+                colorbar.setdefault('location', 'bottom')
             plt.colorbar(collection, ax=ax, **colorbar)
 
         ax.set_xlabel('metres')

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -1423,6 +1423,7 @@ class DSSC_1MGeometry(DetectorGeometryBase):
         collection.set_array(data.ravel())
 
         ax.add_collection(collection)
+        ax.set_facecolor('0.25')
 
         if isinstance(colorbar, dict) or colorbar is True:
             if isinstance(colorbar, bool):

--- a/extra_geom/snapped.py
+++ b/extra_geom/snapped.py
@@ -219,7 +219,7 @@ class SnappedGeometry:
         if isinstance(colorbar, dict) or colorbar is True:
             if isinstance(colorbar, bool):
                 colorbar = {}
-            colorbar = plt.colorbar(im, ax=ax, **colorbar)
+            plt.colorbar(im, ax=ax, **colorbar)
 
         ax.set_xlabel('metres' if axis_units == 'm' else 'pixels')
         ax.set_ylabel('metres' if axis_units == 'm' else 'pixels')

--- a/extra_geom/tests/test_dssc_geometry.py
+++ b/extra_geom/tests/test_dssc_geometry.py
@@ -31,6 +31,15 @@ def test_inspect():
     assert isinstance(ax, Axes)
 
 
+def test_plot_data_hexes():
+    geom = DSSC_1MGeometry.from_h5_file_and_quad_positions(
+        sample_xfel_geom, QUAD_POS
+    )
+    # Smoketest
+    ax = geom.plot_data_hexes(np.zeros((16, 128, 512)), colorbar=True)
+    assert isinstance(ax, Axes)
+
+
 def test_snap_assemble_data():
     geom = DSSC_1MGeometry.from_h5_file_and_quad_positions(
         sample_xfel_geom, QUAD_POS

--- a/extra_geom/tests/test_dssc_geometry.py
+++ b/extra_geom/tests/test_dssc_geometry.py
@@ -39,6 +39,9 @@ def test_plot_data_hexes():
     ax = geom.plot_data_hexes(np.zeros((16, 128, 512)), colorbar=True)
     assert isinstance(ax, Axes)
 
+    ax = geom.plot_data_hexes(np.zeros((128, 512)), module=4, colorbar=True)
+    assert isinstance(ax, Axes)
+
 
 def test_snap_assemble_data():
     geom = DSSC_1MGeometry.from_h5_file_and_quad_positions(


### PR DESCRIPTION
`geom.plot_data_hexes()` takes a stacked frame of DSSC data, and draws each pixel as a hexagon - the difference is only really visible when you zoom in. cc @leguyader, and thanks for the pointers to get started with this.

This is fairly slow, because matplotlib is processing 1M hexagons. I'm guessing it's not something that would be used that often, so performance isn't so important. But maybe we want to add an option to draw only a single module?

![image](https://user-images.githubusercontent.com/327925/173795795-a4758fba-4c21-4da2-8de9-78d16df2e40f.png)

![image](https://user-images.githubusercontent.com/327925/173796250-6734af4b-e9db-4440-a30f-17d43946e245.png)
