### PR TITLE
FIX: JUNGFRAU position_modules with labelled array

### DIFF
--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -8,7 +8,7 @@ import h5py
 import numpy as np
 
 from .base import DetectorGeometryBase, GeometryFragment
-
+from .snapped import isinstance_no_import
 
 class GenericGeometry(DetectorGeometryBase):
     """A generic detector layout based either on the CrystFEL geom file or on a set of parameters.
@@ -1677,6 +1677,13 @@ class JUNGFRAUGeometry(DetectorGeometryBase):
         ss_slice = slice(tile_ss_offset, tile_ss_offset + cls.frag_ss_pixels)
         fs_slice = slice(tile_fs_offset, tile_fs_offset + cls.frag_fs_pixels)
         return ss_slice, fs_slice
+
+    def position_modules(self, data, out=None, threadpool=None):
+        if isinstance_no_import(data, 'xarray', 'DataArray'):
+            # we shift module indices by one as JUNGFRAU labels modules starting from 1..
+            # position_modules returns a numpy array so labels disapear anyway.
+            data['module'] = data['module'] - 1
+        return super().position_modules(data, out=out, threadpool=threadpool)
 
 
 class PNCCDGeometry(DetectorGeometryBase):

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -1682,6 +1682,7 @@ class JUNGFRAUGeometry(DetectorGeometryBase):
         if isinstance_no_import(data, 'xarray', 'DataArray'):
             # we shift module indices by one as JUNGFRAU labels modules starting from 1..
             # position_modules returns a numpy array so labels disapear anyway.
+            data = data.copy(deep=False)
             data['module'] = data['module'] - 1
         return super().position_modules(data, out=out, threadpool=threadpool)
 

--- a/extra_geom/tests/test_jungfrau_geometry.py
+++ b/extra_geom/tests/test_jungfrau_geometry.py
@@ -1,7 +1,11 @@
 
+from tempfile import TemporaryDirectory
+
 import numpy as np
 from cfelpyutils.geometry import load_crystfel_geometry
-
+from extra_data import RunDirectory
+from extra_data.components import JUNGFRAU
+from extra_data.tests.make_examples import make_jungfrau_run
 from extra_geom import JUNGFRAUGeometry
 
 from .utils import assert_geom_close
@@ -63,3 +67,14 @@ def test_get_pixel_positions():
     assert 0.09 > px.max() > 0.07
     assert -0.09 < py.min() < -0.07
     assert 0.09 > py.max() > 0.07
+
+
+def test_position_modules_with_labelled_array():
+    geom = jf4m_geometry()
+
+    with TemporaryDirectory() as td:
+        make_jungfrau_run(td)
+        run = RunDirectory(td).select_trains(np.s_[:5])
+        jf = JUNGFRAU(run)
+        data = jf.get_array('data.adc')
+        positioned, centre = geom.position_modules(data)


### PR DESCRIPTION
It currently fails for labelled array because it expects `module` coortinates to start from `0`, but jungfrau has its modules labelled starting from `1`.