### PR TITLE
Update Python versions tested on Github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Removed 3.6, which it appears is no longer available on `ubuntu-latest` (it errored on #187), and added 3.10.

I'll wait until we've got an h5py release with pre-built Python 3.11 wheels before adding that.