### PR TITLE
Add a method to get the detector centre with sub-pixel accuracy

### DIFF
--- a/extra_geom/base.py
+++ b/extra_geom/base.py
@@ -411,6 +411,23 @@ class DetectorGeometryBase:
             self._snapped_cache = SnappedGeometry(modules, self, centre)
         return self._snapped_cache
 
+    def centre(self, snapped=False):
+        """Return the centre of the detector in (y, x) pixel coordinates.
+
+        Parameters
+        ----------
+        snapped: bool, optional
+          By default the center will be returned with sub-pixel accuracy, but if
+          this parameter is True then the approximate rounded coordinates will
+          be returned.
+        """
+        if snapped:
+            return self._snapped().centre
+
+        tile_corners = [t.corner_pos[:2] for t in
+                        chain.from_iterable(self.modules)]
+        return np.abs(np.min(tile_corners, axis=0))[::-1] / self.pixel_size
+
     @staticmethod
     def split_tiles(module_data):
         """Split data from a detector module into tiles.

--- a/extra_geom/tests/test_agipd_geometry.py
+++ b/extra_geom/tests/test_agipd_geometry.py
@@ -249,3 +249,22 @@ def test_to_pyfai_detector():
     )
     agipd_pyfai = geom.to_pyfai_detector()
     assert isinstance(agipd_pyfai, pyFAI.detectors.Detector)
+
+
+def test_centre():
+    geom = AGIPD_1MGeometry.from_quad_positions(
+        quad_pos=[(-525, 625), (-550, -10), (520, -160), (542.5, 475)]
+    )
+
+    snapped_centre = geom._snapped().centre
+    np.testing.assert_equal(geom.centre(), snapped_centre)
+    np.testing.assert_equal(geom.centre(snapped=True), snapped_centre)
+
+    dx = 0.5
+    dy = 0.25
+    # A positive upwards shift of the modules means a negative downwards shift
+    # of the detector centre.
+    new_geom = geom.offset((dx * geom.pixel_size, dy * geom.pixel_size))
+    new_centre = snapped_centre - [dy, dx]
+    np.testing.assert_equal(new_geom.centre(), new_centre)
+    np.testing.assert_equal(new_geom.centre(snapped=True), snapped_centre)


### PR DESCRIPTION
Before it was only possible to get the 'snapped' center from `geom.position_modules()`.

BTW I tried testing this with the `GenericGeometry` class, but it didn't really work because methods like `.offset()` create a new geometry object that don't include non-class attributes like `.pixel_size`. Not sure if that's a bug worth fixing.