### PR TITLE
Allow older versions of Pillow on older Pythons

### DIFF
--- a/.github/dependabot/constraints.txt
+++ b/.github/dependabot/constraints.txt
@@ -8,7 +8,7 @@ kiwisolver==1.4.4
 matplotlib<3.8.0
 nbval==0.10.0
 numpy<1.25.0
-Pillow==10.0.0
+Pillow<10.1.0
 pyFAI==2023.5.0
 pyparsing==3.0.9
 pytest<7.5.0


### PR DESCRIPTION
I didn't notice when merging #233, but the constraint `Pillow==10.0.0` causes Python 3.7 to walk back through old matplotlib versions until it finds one that doesn't require Pillow at all. EXtra-geom still passes the tests with that old version, whereas EXtra-data doesn't.