### PR TITLE
Implement example geometries for all detectors

### DIFF
--- a/.github/dependabot/constraints.txt
+++ b/.github/dependabot/constraints.txt
@@ -7,6 +7,7 @@ h5py<3.10.0
 kiwisolver==1.4.5
 matplotlib<3.8.0
 nbval==0.10.0
+numexpr==2.8.4
 numpy<1.26.0
 Pillow<10.1.0
 pyFAI==2023.5.0

--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -41,6 +41,8 @@ but this geometry code works with a position for each tile.
 
    .. automethod:: from_crystfel_geom
 
+   .. automethod:: example
+
    .. automethod:: offset
 
    .. automethod:: rotate
@@ -97,6 +99,8 @@ but this geometry code works with a position for each tile.
 
    .. automethod:: write_crystfel_geom
 
+   .. automethod:: example
+
    .. automethod:: get_pixel_positions
 
    .. automethod:: to_distortion_array
@@ -141,6 +145,8 @@ which this geometry code can position independently.
    .. automethod:: from_h5_file
 
    .. automethod:: from_crystfel_geom
+
+   .. automethod:: example
 
    .. automethod:: offset
 
@@ -187,6 +193,8 @@ two 32×128 tiles.
 .. autoclass:: LPD_MiniGeometry
 
    .. automethod:: from_module_positions
+
+   .. automethod:: example
 
    .. automethod:: offset
 
@@ -244,6 +252,8 @@ approximately half a pixel width from their true position.
 
    .. automethod:: from_h5_file
 
+   .. automethod:: example
+
    .. automethod:: offset
 
    .. automethod:: rotate
@@ -290,6 +300,8 @@ Each module is further subdivided into 8 sensor tiles.
 
    .. automethod:: from_crystfel_geom
 
+   .. automethod:: example
+
    .. automethod:: write_crystfel_geom
 
    .. automethod:: get_pixel_positions
@@ -322,6 +334,8 @@ single tile.
 
    .. automethod:: from_absolute_positions
 
+   .. automethod:: example
+
    .. automethod:: plot_data
 
    .. automethod:: position_modules
@@ -341,15 +355,25 @@ ePix100 detectors have one module of 704 × 768 pixels. Module built from 4 ASIC
 
 ePix10K detectors have one module of 352 × 384 pixels. Module built from 4 ASICs with 176 rows and 192 columns of pixels with wide pixes on inner edges. Normal pixels are 100 × 100 um.
 
-.. note:: References are given for :class:`Epix100Geometry` providing ePix100 layout. For ePix10K, use :class:`Epix10KGeometry` with the same interface.
+.. note:: Only methods unique to the :class:`Epix100Geometry` class are
+          documented, but it otherwise has the same interface as
+          :class:`Epix10KGeometry`.
 
 .. autoclass:: Epix100Geometry
 
-   .. automethod:: from_origin
-
    .. automethod:: from_relative_positions
 
+   .. automethod:: pair_geometry
+
+.. autoclass:: Epix10KGeometry
+
+   .. automethod:: from_origin
+
    .. automethod:: from_crystfel_geom
+
+   .. automethod:: monolithic_geometry
+
+   .. automethod:: example
 
    .. automethod:: write_crystfel_geom
 

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -2298,7 +2298,7 @@ class EpixGeometryBase(DetectorGeometryBase):
 
     @classmethod
     def from_origin(cls, origin=(0, 0), asic_gap=None, unit=None):
-        """Generate an ePix100 geometry from origin position.
+        """Generate a geometry from origin position.
 
         This produces an idealised geometry, assuming all modules are perfectly
         flat, aligned and equally spaced within the detector.
@@ -2311,19 +2311,6 @@ class EpixGeometryBase(DetectorGeometryBase):
         To give positions in units other than pixels, pass the *unit* parameter
         as the length of the unit in metres. E.g. ``unit=1e-3`` means the
         coordinates are in millimetres.
-
-        .. note::
-
-            ePix100 has 2 different geometry layout:
-
-            - A single monolithic sensor with a 2x2 array of four ASICs bonded to it.
-              These would have no dead gaps but would have large pixels in the central
-              cross. This is the current default gap implementation.
-            - A pair of sensors with each sensor being bonded to two ASICs.
-              These would have a dead gap equal to twice the guard ring width (~450-500um)
-              plus a mechanical gap of about 200-300 microns. This would result in a total
-              dead gap of about 1.25 millimeters.
-              For this case see :meth:`from_relative_positions`
         """
         if unit is None:
             unit = cls.pixel_size
@@ -2498,6 +2485,19 @@ class Epix100Geometry(EpixGeometryBase):
     They have the same electronics as normal pixels but aren't wired
     to the sensor. They are two first and two last rows in the raw data
     array. This class assumes that calibration rows are cut.
+
+    .. note::
+
+        The ePix100 has 2 different geometry layouts:
+
+        - A single monolithic sensor with a 2x2 array of four ASICs bonded to it.
+          These would have no dead gaps but would have large pixels in the central
+          cross. Use :meth:`Epix10KGeometry.monolithic_geometry` to generate this geometry.
+        - A pair of sensors with each sensor being bonded to two ASICs.
+          These would have a dead gap equal to twice the guard ring width (~450-500um)
+          plus a mechanical gap of about 200-300 microns. This would result in a total
+          dead gap of about 1.25 millimeters. For this case use
+          :meth:`pair_geometry`.
     """
     detector_type_name = 'ePix100'
     pixel_size = 50e-6
@@ -2514,25 +2514,7 @@ class Epix100Geometry(EpixGeometryBase):
     @classmethod
     def from_relative_positions(cls, asic_gap=None, unit=None, top=(0., 0., 0.),
                                 bottom=(0., 0., 0.)):
-        """Generate an ePix100 geometry from relative Asics-pair positions.
-
-        ePix100 has 2 assemblies:
-
-        - a single monolithic sensor with a 2x2 array of four ASICs bonded to it. These
-          would have no dead gaps but would have large pixels in the central cross.
-          Use :meth:`from_origin` if your detector has this layout.
-        - A pair of sensors with each sensor being bonded to two ASICs. These would have
-          a dead gap equal to twice the guard ring width (~450-500um) plus a mechanical
-          gap of about 200-300 microns. This would result in a total dead gap of about
-          1.25 millimeters.
-
-        For the later case, one can determine determine the exact gap existing between
-        the 2 (top and bottom) asic pair. A rough estimation of the gap has been seen at
-        ~25 pixels. This can be generated with::
-
-            geom = Epix100Geometry.from_relative_positions(
-                top=[386.5, 364.5, 0.], bottom=[386.5, -12.5, 0.]
-            )
+        """Generate an ePix100 geometry from relative ASICS-pair positions.
 
         Parameters
         ----------

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -265,6 +265,16 @@ class AGIPD_1MGeometry(DetectorGeometryBase):
                 ))
         return cls(modules)
 
+    @classmethod
+    def example(cls):
+        """Create an example geometry (useful for quick visualization)."""
+        return cls.from_quad_positions([
+            (-525, 625),
+            (-550, -10),
+            (520, -160),
+            (542.5, 475)
+        ])
+
     def quad_positions(self):
         """Retrieve the coordinates of the first pixel in each quadrant
 
@@ -518,6 +528,11 @@ class AGIPD_500K2GGeometry(DetectorGeometryBase):
                 ))
 
         return cls(modules)
+
+    @classmethod
+    def example(cls):
+        """Create an example geometry (useful for quick visualization)."""
+        return cls.from_origin()
 
     def inspect(self, axis_units='px', frontview=True):
         """Plot the 2D layout of this detector geometry.
@@ -818,6 +833,16 @@ class LPD_1MGeometry(LPDGeometryBase):
 
         return cls.from_h5_file_and_quad_positions(path, quadpos)
 
+    @classmethod
+    def example(cls):
+        """Create an example geometry (useful for quick visualization)."""
+        return cls.from_quad_positions([
+            (11.4, 299),
+            (-11.5, 8),
+            (254.5, -16),
+            (278.5, 275)
+        ])
+
     def to_h5_file_and_quad_positions(self, path):
         """Write this geometry to an XFEL HDF5 format geometry file
 
@@ -1087,6 +1112,20 @@ class LPD_MiniGeometry(LPDGeometryBase):
             )])
 
         return cls(modules)
+
+    @classmethod
+    def example(cls, n_modules=1):
+        """Create an example geometry (useful for quick visualization)."""
+        asic_gap = 4
+        module_gap_y = 5
+        mod_height = cls.n_tiles_per_module * 32 + asic_gap
+
+        module_positions = []
+        for i in range(n_modules):
+            y = (mod_height / 2) * i + (i * module_gap_y)
+            module_positions.append((0, y))
+
+        return cls.from_module_positions(module_positions)
 
     def inspect(self, axis_units='px', frontview=True):
         """Plot the 2D layout of this detector geometry.
@@ -1398,6 +1437,16 @@ class DSSC_1MGeometry(DetectorGeometryBase):
                 )
 
         return cls.from_h5_file_and_quad_positions(path, quadpos)
+
+    @classmethod
+    def example(cls):
+        """Create an example geometry (useful for quick visualization)."""
+        return cls.from_quad_positions([
+            (-130, 5),
+            (-130, -125),
+            (5, -125),
+            (5, 5)
+        ])
 
     def to_h5_file_and_quad_positions(self, path):
         """Write this geometry to an XFEL HDF5 format geometry file
@@ -1895,6 +1944,31 @@ class JUNGFRAUGeometry(DetectorGeometryBase):
             modules.append(tiles)
         return cls(modules)
 
+    @classmethod
+    def example(cls, n_modules=1):
+        """Create an example geometry (useful for quick visualization)."""
+        asic_gap = 2
+        module_gap_x = 100
+        module_gap_y = 20
+        cols = 2
+
+        tiles_per_row = cls.expected_data_shape[2] // cls.frag_fs_pixels
+        tiles_per_col = cls.expected_data_shape[1] // cls.frag_ss_pixels
+        mod_width = (cls.frag_fs_pixels * tiles_per_row) + (asic_gap * (tiles_per_row - 1))
+        mod_height = (cls.frag_ss_pixels * tiles_per_col) + (asic_gap * (tiles_per_col - 1))
+
+        module_positions = []
+        x_start = -mod_width
+
+        for i in range(n_modules):
+            row = i // cols
+            col = i - (row * cols)
+            x = x_start - mod_width * col - (col * module_gap_x)
+            y = mod_height * row + (row * module_gap_y)
+            module_positions.append((x, y))
+
+        return cls.from_module_positions(module_positions)
+
     def inspect(self, axis_units='px', frontview=True, module_names=[]):
         """Plot the 2D layout of this detector geometry.
 
@@ -2086,6 +2160,11 @@ class PNCCDGeometry(DetectorGeometryBase):
                     [GeometryFragment(np.array(bottom), *args)]])
 
     @classmethod
+    def example(cls):
+        """Create an example geometry (useful for quick visualization)."""
+        return cls.from_relative_positions()
+
+    @classmethod
     def _ensure_shape(cls, data):
         """Ensure image data has the proper shape.
 
@@ -2269,6 +2348,11 @@ class EpixGeometryBase(DetectorGeometryBase):
                 fs_pixels=cls.frag_fs_pixels,
             ))
         return cls([tiles])
+
+    @classmethod
+    def monolithic_geometry(cls):
+        """Return the geometry for an ePix100/ePix10K with a single monolithic sensor."""
+        return cls.from_origin([0, 0])
 
     @classmethod
     def _module_coords_to_tile(cls, slow_scan, fast_scan):
@@ -2476,6 +2560,24 @@ class Epix100Geometry(EpixGeometryBase):
             for tile, pos, ref in zip(geom.modules[0], position, reference)
         ]])
 
+    @classmethod
+    def pair_geometry(cls):
+        """Return the geometry for an ePix100 with a pair of sensors.
+
+        One can determine the exact gap existing between the 2 (top and bottom)
+        ASIC pairs. A rough estimation of the gap has been seen at ~25
+        pixels, which is what this method will generate a geometry with.
+        """
+        return cls.from_relative_positions(
+            top=[386.5, 364.5, 0],
+            bottom=[386.5, -12.5, 0]
+        )
+
+    @classmethod
+    def example(cls):
+        """Create an example geometry (useful for quick visualization)."""
+        return cls.monolithic_geometry()
+
 
 class Epix10KGeometry(EpixGeometryBase):
     """Detector layout for ePix10K
@@ -2503,3 +2605,8 @@ class Epix10KGeometry(EpixGeometryBase):
         2 * frag_ss_pixels,
         2 * frag_fs_pixels
     )
+
+    @classmethod
+    def example(cls):
+        """Create an example geometry (useful for quick visualization)."""
+        return cls.monolithic_geometry()

--- a/extra_geom/tests/test_agipd500k2g_geometry.py
+++ b/extra_geom/tests/test_agipd500k2g_geometry.py
@@ -120,7 +120,7 @@ def test_write_read_crystfel_file_2d(tmpdir):
 
 
 def test_inspect():
-    geom = AGIPD_500K2GGeometry.from_origin()
+    geom = AGIPD_500K2GGeometry.example()
     # Smoketest
     ax = geom.inspect()
     assert isinstance(ax, Axes)

--- a/extra_geom/tests/test_agipd_geometry.py
+++ b/extra_geom/tests/test_agipd_geometry.py
@@ -163,9 +163,7 @@ def test_quad_positions():
 
 
 def test_inspect():
-    geom = AGIPD_1MGeometry.from_quad_positions(
-        quad_pos=[(-525, 625), (-550, -10), (520, -160), (542.5, 475)]
-    )
+    geom = AGIPD_1MGeometry.example()
     # Smoketest
     ax = geom.inspect()
     assert isinstance(ax, Axes)

--- a/extra_geom/tests/test_dssc_geometry.py
+++ b/extra_geom/tests/test_dssc_geometry.py
@@ -24,9 +24,7 @@ QUAD_POS = [
 
 
 def test_inspect():
-    geom = DSSC_1MGeometry.from_h5_file_and_quad_positions(
-        sample_xfel_geom, QUAD_POS
-    )
+    geom = DSSC_1MGeometry.example()
     # Smoketest
     ax = geom.inspect()
     assert isinstance(ax, Axes)

--- a/extra_geom/tests/test_epix_geometry.py
+++ b/extra_geom/tests/test_epix_geometry.py
@@ -188,3 +188,10 @@ def test_ensure_shape(args, shape):
            epix.frag_fs_pixels * 2 + epix.asic_gap)
     )
     np.testing.assert_allclose(img.shape, expected_img_shape, atol=1)
+
+def test_default_geometries():
+    # Smoke tests
+    Epix100Geometry.pair_geometry()
+    Epix10KGeometry.monolithic_geometry()
+    Epix100Geometry.example()
+    Epix10KGeometry.example()

--- a/extra_geom/tests/test_jungfrau_geometry.py
+++ b/extra_geom/tests/test_jungfrau_geometry.py
@@ -3,6 +3,7 @@ from tempfile import TemporaryDirectory
 
 import numpy as np
 import pyFAI.detectors
+from matplotlib.axes import Axes
 from cfelpyutils.geometry import load_crystfel_geometry
 from extra_data import RunDirectory
 from extra_data.components import JUNGFRAU
@@ -86,3 +87,13 @@ def test_to_pyfai_detector():
     jf4m_pyfai = geom.to_pyfai_detector()
     assert isinstance(jf4m_pyfai, pyFAI.detectors.Detector)
     assert jf4m_pyfai.MAX_SHAPE == (8*512, 1024)
+
+
+def test_inspect():
+    # Smoke test
+    geom = JUNGFRAUGeometry.example(n_modules=8)
+
+    # Smoketest
+    ax = geom.inspect()
+    assert isinstance(ax, Axes)
+

--- a/extra_geom/tests/test_lpd_geometry.py
+++ b/extra_geom/tests/test_lpd_geometry.py
@@ -245,9 +245,7 @@ def test_rotate():
 
 
 def test_inspect():
-    geom = LPD_1MGeometry.from_quad_positions(
-        [(11.4, 299), (-11.5, 8), (254.5, -16), (278.5, 275)]
-    )
+    geom = LPD_1MGeometry.example()
     # Smoketest
     ax = geom.inspect()
     assert isinstance(ax, Axes)

--- a/extra_geom/tests/test_lpdmini_geometry.py
+++ b/extra_geom/tests/test_lpdmini_geometry.py
@@ -104,7 +104,7 @@ def test_rotate():
 
 
 def test_inspect():
-    geom = LPD_MiniGeometry.from_module_positions([(0, 0)])
+    geom = LPD_MiniGeometry.example(4)
     # Smoketest
     ax = geom.inspect()
     assert isinstance(ax, Axes)

--- a/extra_geom/tests/test_pnccd_geometry.py
+++ b/extra_geom/tests/test_pnccd_geometry.py
@@ -53,7 +53,7 @@ def test_snap_assemble_data(shape):
     assert img[50, 50] == 0
 
 def test_inspect():
-    geom = PNCCDGeometry.from_relative_positions()
+    geom = PNCCDGeometry.example()
 
     # Smoketest
     ax = geom.inspect()


### PR DESCRIPTION
We discussed this ages ago on Zulip (see the `Default geometries?` topic) but never got around to implementing it. I think most of the changes here are fairly straightforward, except for the LPD mini and JF which can have a variable number of modules. Here's what they look like:
![image](https://github.com/European-XFEL/EXtra-geom/assets/5361518/5684d5e6-5d8c-42a3-9b26-7845a01b2c86)
![image](https://github.com/European-XFEL/EXtra-geom/assets/5361518/a95bb847-003a-435c-bb07-ca5d837125e6)

The odd thing compared to the examples is that the origin is not centered. I tried centering it but got very confused and gave up :shrug: Geometry is quite bamboozling...

Some other things:
- You could argue that `PNCCDGeometry` and the epix classes don't need a `.example()` because some of their existing methods already have reasonable defaults. I'd say that it's good to have `.example()` methods anyway for consistency, but I don't feel very strongly about it.
- Going a bit further than `.example()`, the epix classes now have 'real' geometry methods `.monolithic_geometry()` and `.pair_geometry()` for convenience.