### PR TITLE
Prepare to release 1.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,14 +16,14 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('**/setup.py') }}-${{ hashFiles('.github/dependabot/constraints.txt') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,3 +41,27 @@ jobs:
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
+
+  publish:
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    needs: tests
+    permissions:
+      id-token: write  # OIDC for uploading to PyPI
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Build packages
+        run: |
+          python3 -m pip install build
+          python3 -m build
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,17 @@
 Release Notes
 =============
 
+1.12
+----
+
+2024-05-22
+
+- :ref:`det-AGIPD-1M` detector geometry can now be updated using the positions
+  from the 8 quadrant motors (:ghpull:`269`). A reference geometry is required
+  as a starting point, and a new geometry can be created based on the changes in
+  the motor positions. See :doc:`motor_based_geometry` for an example of how to
+  use this.
+
 1.11
 ----
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Release Notes
 1.12
 ----
 
-2024-05-22
+2024-05-27
 
 - :ref:`det-AGIPD-1M` detector geometry can now be updated using the positions
   from the 8 quadrant motors (:ghpull:`269`). A reference geometry is required

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -295,4 +295,4 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}


### PR DESCRIPTION
- Add a release note summarising PR #269
- Set up Github actions to publish tags to PyPI, copying the workflow from EXtra-data (I've also set up the PyPI side of this)
- Fix a warning from Sphinx