### PR TITLE
Switch PyFAI links to use silx.org

### DIFF
--- a/docs/dssc_geometry.ipynb
+++ b/docs/dssc_geometry.ipynb
@@ -130,7 +130,7 @@
     "DSSC has unusual hexagonal pixels. Assembling an image treats the pixels as uniform rectangles so that one input pixel is one output pixel, but the geometry object does know about the real shape and layout of the pixels.\n",
     "\n",
     "Let's have a close up look at some pixels in Q1M1. `get_pixel_positions()` gives us pixel centres.\n",
-    "`to_distortion_array()` gives pixel corners in a slightly different format, suitable for [PyFAI](https://pyfai.readthedocs.io/).\n",
+    "`to_distortion_array()` gives pixel corners in a slightly different format, suitable for [PyFAI](https://www.silx.org/doc/pyFAI/latest/).\n",
     "\n",
     "PyFAI requires non-negative x and y coordinates. But we want to plot them along with the centre positions, so we pass `allow_negative_xy=True` to get comparable coordinates."
    ]

--- a/docs/pyfai.ipynb
+++ b/docs/pyfai.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "![azimuthal integration diagram](azimuthal-int-diagram.png)\n",
     "\n",
-    "The [PyFAI package](https://pyfai.readthedocs.io/), developed at ESRF, performs azimuthal integration with a range of different options and methods."
+    "The [PyFAI package](https://www.silx.org/doc/pyFAI/latest/), developed at ESRF, performs azimuthal integration with a range of different options and methods."
    ]
   },
   {
@@ -337,7 +337,7 @@
     "\n",
     "-----\n",
     "\n",
-    "[PyFAI](https://pyfai.readthedocs.io/) is a very powerful library, with extensive documentation of its own. This example has only scratched the surface. PyFAI's [introductory tutorial](https://pyfai.readthedocs.io/en/stable/usage/tutorial/Introduction/introduction.html) and [AzimuthalIntegrator API docs](https://pyfai.readthedocs.io/en/stable/api/pyFAI.html#pyFAI.azimuthalIntegrator.AzimuthalIntegrator) are particularly useful starting points to find out more."
+    "[PyFAI](https://www.silx.org/doc/pyFAI/latest/) is a very powerful library, with extensive documentation of its own. This example has only scratched the surface. PyFAI's [introductory tutorial](https://www.silx.org/doc/pyFAI/latest/usage/tutorial/Introduction/introduction.html) and [AzimuthalIntegrator API docs](https://www.silx.org/doc/pyFAI/latest/api/pyFAI.html#pyFAI.azimuthalIntegrator.AzimuthalIntegrator) are particularly useful starting points to find out more."
    ]
   }
  ],


### PR DESCRIPTION
@kif tells me the silx.org domain is the preferred location.