### PR TITLE
Fix rotate() direction to match what is described in the docs (right-handed convention)

### DIFF
--- a/extra_geom/base.py
+++ b/extra_geom/base.py
@@ -58,9 +58,9 @@ class GeometryFragment:
         return type(self)(pos, self.ss_vec, self.fs_vec, self.ss_pixels, self.fs_pixels)
 
     def rotate(self, matrix, center):
-        ss_vec = self.ss_vec @ matrix
-        fs_vec = self.fs_vec @ matrix
-        pos = (self.corner_pos - center) @ matrix + center
+        ss_vec = matrix @ self.ss_vec
+        fs_vec = matrix @ self.fs_vec
+        pos = (matrix @ (self.corner_pos - center)) + center
         return type(self)(pos, ss_vec, fs_vec, self.ss_pixels, self.fs_pixels)
 
     def snap(self, px_shape):


### PR DESCRIPTION
I noticed recently that the `.rotate()` method works in the opposite direction to what the docs describe. The docs say:

> - Positive x angles tilt the top edge of the detector backwards, away from the source
> - Positive y angles tilt the right-hand edge (looking along the beam) away from the source
> - Positive z angles turn the detector clockwise (looking along the beam)

However, the precise opposite was true. The tests missed this because they relied on rotating through 90 or 180 degrees and checking the plane of the points - this doesn't depend on the rotation direction.

This will unfortunately break any code which used the `.rotate()` method already and has adapted to its backwards nature. However I think this is not widely used, and the right-handed convention seems to be generally widespread (e.g. [Wikipedia](https://en.wikipedia.org/wiki/Euler_angles#Signs,_ranges_and_conventions)), so I don't want to stick with the opposite convention just for compatibility.

