### PR TITLE
Fix telling PyFAI about JUNGFRAU detector shape

### DIFF
--- a/extra_geom/pyfai.py
+++ b/extra_geom/pyfai.py
@@ -58,5 +58,5 @@ class JUNGFRAU_EuXFEL(Detector):
     IS_CONTIGUOUS = False
 
     def __init__(self, pixel1=7.5e-5, pixel2=7.5e-5, n_modules=1, **kwargs):
-        self.MAX_SHAPE = (n_modules*512, 1024)
-        super().__init__(pixel1, pixel2, **kwargs)
+        self.MAX_SHAPE = max_shape = (n_modules*512, 1024)
+        super().__init__(pixel1, pixel2, max_shape=max_shape, **kwargs)

--- a/extra_geom/tests/test_jungfrau_geometry.py
+++ b/extra_geom/tests/test_jungfrau_geometry.py
@@ -3,6 +3,7 @@ from tempfile import TemporaryDirectory
 
 import numpy as np
 import pyFAI.detectors
+import pyFAI.azimuthalIntegrator
 from matplotlib.axes import Axes
 from cfelpyutils.geometry import load_crystfel_geometry
 from extra_data import RunDirectory
@@ -86,7 +87,10 @@ def test_to_pyfai_detector():
     geom = jf4m_geometry()
     jf4m_pyfai = geom.to_pyfai_detector()
     assert isinstance(jf4m_pyfai, pyFAI.detectors.Detector)
-    assert jf4m_pyfai.MAX_SHAPE == (8*512, 1024)
+    assert jf4m_pyfai.shape == (8*512, 1024)
+
+    ai = pyFAI.azimuthalIntegrator.AzimuthalIntegrator(detector=jf4m_pyfai)
+    assert ai.array_from_unit(unit='r_m').shape == (8*512, 1024)
 
 
 def test_inspect():


### PR DESCRIPTION
Fixes part of an issue we ran into (& have worked around) combining LPD & JUNGFRAU in a PyFAI MultiGeometry object.

The other part needed to remove the workaround is https://github.com/silx-kit/pyFAI/pull/2464