### PR TITLE
Feat: assemble modules interpolate

### DIFF
--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -13,13 +13,15 @@ This should be roughly where the beam passes through the detector.
 They follow the standard European XFEL axis orientations, with x increasing to
 the left (looking along the beam), and y increasing upwards.
 
-.. note::
-
-   This module includes methods to assemble data into a single array.
-   This is sufficient for a quick examination of detector images, but the
-   detector pixels may not line up with the grid imposed by a single array.
-   For accurate analysis, it's best to use a tool that can process
-   geometry internally with sub-pixel precision.
+This module includes
+:meth:`~extra_geom.DetectorGeometryBase.position_modules_interpolate` to
+assemble data into a single 2D array with pixel splitting, conserving total
+signal (using pyFAI's
+[Distorsion](https://pyfai.readthedocs.io/en/stable/usage/tutorial/Detector/Distortion/Distortion.html)
+module). For accurate analysis, it 's still best to use tools that can process
+geometry without relying on assembled images, both for performance and
+correctness. However, this method can be useful for previewing data, or for
+processing with tools that require images of the complete detector.
 
 .. _det-AGIPD-1M:
 
@@ -109,6 +111,8 @@ but this geometry code works with a position for each tile.
 
    .. automethod:: plot_data
 
+   .. automethod:: position_modules_interpolate
+
    .. automethod:: position_modules
 
    .. automethod:: output_array_for_position
@@ -166,6 +170,8 @@ which this geometry code can position independently.
 
    .. automethod:: plot_data
 
+   .. automethod:: position_modules_interpolate
+
    .. automethod:: position_modules
 
    .. automethod:: output_array_for_position
@@ -211,6 +217,8 @@ two 32×128 tiles.
    .. automethod:: plot_data
 
    .. automethod:: output_array_for_position
+
+   .. automethod:: position_modules_interpolate
 
    .. automethod:: position_modules_symmetric
 
@@ -312,6 +320,8 @@ Each module is further subdivided into 8 sensor tiles.
 
    .. automethod:: plot_data
 
+   .. automethod:: position_modules_interpolate
+
    .. automethod:: position_modules
 
    .. automethod:: output_array_for_position
@@ -341,6 +351,8 @@ single tile.
    .. automethod:: example
 
    .. automethod:: plot_data
+
+   .. automethod:: position_modules_interpolate
 
    .. automethod:: position_modules
 
@@ -384,6 +396,8 @@ ePix10K detectors have one module of 352 × 384 pixels. Module built from 4 ASIC
    .. automethod:: get_pixel_positions
 
    .. automethod:: plot_data
+
+   .. automethod:: position_modules_interpolate
 
    .. automethod:: position_modules
 

--- a/docs/geometry.rst
+++ b/docs/geometry.rst
@@ -17,11 +17,13 @@ This module includes
 :meth:`~extra_geom.DetectorGeometryBase.position_modules_interpolate` to
 assemble data into a single 2D array with pixel splitting, conserving total
 signal (using pyFAI's
-[Distorsion](https://pyfai.readthedocs.io/en/stable/usage/tutorial/Detector/Distortion/Distortion.html)
-module). For accurate analysis, it 's still best to use tools that can process
+[Distortion](https://pyfai.readthedocs.io/en/stable/usage/tutorial/Detector/Distortion/Distortion.html)
+module). For accurate analysis, it's still best to use tools that can process
 geometry without relying on assembled images, both for performance and
 correctness. However, this method can be useful for previewing data, or for
 processing with tools that require images of the complete detector.
+:meth:`~extra_geom.DetectorGeometryBase.position_modules` gives a faster but
+less accurate geometry assembly snapping detector pixels to a regular grid.
 
 .. _det-AGIPD-1M:
 

--- a/extra_geom/base.py
+++ b/extra_geom/base.py
@@ -528,7 +528,7 @@ class DetectorGeometryBase:
           Subdivide output pixels by this factor in each dimension.
         output_pixel_size : float or (float, float), optional
           Output pixel size in metres as ``(x, y)``. If omitted, defaults to
-          :attr:`_pixel_shape`.
+          the detector pixel size.
         resize : bool
           If True (default), expand the output array to include all pixels so
           total signal is preserved.
@@ -580,7 +580,6 @@ class DetectorGeometryBase:
             ) from exc
 
         # Prepare input data as a numpy array with module axis at -3
-        modules_present = None
         if isinstance_no_import(data, 'xarray', 'DataArray'):
             modnos = data.coords.get('module')
             if modnos is None:

--- a/extra_geom/base.py
+++ b/extra_geom/base.py
@@ -5,8 +5,9 @@ from warnings import warn
 import numpy as np
 
 from .crystfel_fmt import write_crystfel_geom
-from .snapped import GridGeometryFragment, SnappedGeometry
 from .motors import read_motors_from_geom
+from .snapped import (GridGeometryFragment, SnappedGeometry,
+                      isinstance_no_import)
 
 
 class GeometryFragment:
@@ -501,6 +502,165 @@ class DetectorGeometryBase:
         """Deprecated alias for :meth:`position_modules`"""
         return self.position_modules(data, out=out)
 
+    def position_modules_interpolate(
+        self,
+        data,
+        *,
+        oversample: int = 1,
+        output_pixel_size=None,
+        resize: bool = True,
+        method: str = "LUT",
+        empty=np.nan,
+        device: str | None = None,
+        dis_kwargs: dict | None = None,
+    ):
+        """Assemble data onto a regular grid using pixel-splitting.
+
+        This uses pyFAI's distortion correction machinery to produce an output
+        image corrected from spatial distortion.
+
+        Parameters
+        ----------
+        data : ndarray or xarray.DataArray
+          Detector data shaped like :attr:`expected_data_shape`, optionally with
+          extra leading dimensions.
+        oversample : int
+          Subdivide output pixels by this factor in each dimension.
+        output_pixel_size : float or (float, float), optional
+          Output pixel size in metres as ``(x, y)``. If omitted, defaults to
+          :attr:`_pixel_shape`.
+        resize : bool
+          If True (default), expand the output array to include all pixels so
+          total signal is preserved.
+        method : str
+          pyFAI distortion backend, e.g. "CSR" or "LUT" (default).
+        empty : float
+          Value for empty output pixels.
+        device : str, optional
+          Name of the device: None for OpenMP, "cpu" or "gpu" or the id of
+          the OpenCL device a 2-tuple of integer.
+        dis_kwargs : dict, optional
+          Extra arguments passed to pyFAI's ``Distortion.correct_ng()``.
+
+        Returns
+        -------
+        out : ndarray
+          Assembled image array (counts), with the module dimension removed.
+        centre : ndarray
+          (y, x) output pixel coordinates of the detector centre.
+        """
+        ncorners = self._pixel_corners.shape[1]
+        if ncorners != 4:
+            raise NotImplementedError(
+                "Interpolated assembly currently supports only quadrilateral "
+                f"pixels; this geometry has {ncorners} corners per pixel."
+            )
+
+        if oversample < 1 or int(oversample) != oversample:
+            raise ValueError(f"oversample must be a positive integer, got {oversample!r}")
+        oversample = int(oversample)
+
+        nmod, mod_ss, mod_fs = self.expected_data_shape
+
+        if output_pixel_size is None:
+            dx, dy = (np.asarray(self._pixel_shape, dtype=np.float64) / oversample)
+        else:
+            if np.isscalar(output_pixel_size):
+                dx = dy = float(output_pixel_size) / oversample
+            else:
+                dx = float(output_pixel_size[0]) / oversample
+                dy = float(output_pixel_size[1]) / oversample
+
+        try:
+            from pyFAI.distortion import Distortion
+        except ImportError as exc:
+            raise ImportError(
+                "pyFAI is required for interpolated assembly. "
+                "Install pyFAI (e.g. `pip install pyFAI`) to use."
+            ) from exc
+
+        # Prepare input data as a numpy array with module axis at -3
+        modules_present = None
+        if isinstance_no_import(data, 'xarray', 'DataArray'):
+            modnos = data.coords.get('module')
+            if modnos is None:
+                raise ValueError("xarray arrays should have a dimension named 'module'")
+            modnos = np.asarray(modnos.values)
+            if (modnos < 0).any() or (modnos >= nmod).any():
+                raise ValueError(
+                    f"module number labels should be in the range 0-{nmod-1} "
+                    f"(found {modnos.min()}-{modnos.max()})"
+                )
+            if data.shape[-2:] != (mod_ss, mod_fs):
+                raise ValueError(
+                    f"Wrong pixel dimensions for detector modules: {data.shape[-2:]} "
+                    f"- expected {(mod_ss, mod_fs)})"
+                )
+
+            mod_dim_ix = data.dims.index('module')
+            arr = np.moveaxis(data.values, mod_dim_ix, -3)
+            extra_shape = arr.shape[:-3]
+            if arr.shape[-2:] != (mod_ss, mod_fs):
+                raise ValueError(
+                    f"Wrong pixel dimensions for detector modules: {arr.shape[-2:]} "
+                    f"- expected {(mod_ss, mod_fs)})"
+                )
+
+            modules_present = np.zeros((nmod,), dtype=bool)
+            modules_present[modnos] = True
+
+            if modules_present.all():
+                data_np = arr
+            else:
+                # Fill missing modules with 0 so they contribute nothing.
+                data_np = np.zeros(extra_shape + (nmod, mod_ss, mod_fs), dtype=arr.dtype)
+                for i, modno in enumerate(modnos):
+                    data_np[..., modno, :, :] = arr[..., i, :, :]
+        else:
+            if data.shape[-3:] != self.expected_data_shape:
+                raise ValueError(
+                    f"Wrong shape for detector data: {data.shape} does not end "
+                    f"with {self.expected_data_shape}"
+                )
+            data_np = data
+            extra_shape = data_np.shape[:-3]
+
+        # Build a pyFAI detector.
+        det = self.to_pyfai_detector(
+            pixel1=dy, pixel2=dx, max_shape=(nmod * mod_ss, mod_fs)
+        )
+        # pyFAI Distortion expects a mask array
+        det.mask = np.zeros((nmod * mod_ss, mod_fs), dtype=np.int8)
+
+        dis = Distortion(
+            det,
+            shape=None if resize else (nmod * mod_ss, mod_fs),
+            resize=resize,
+            empty=empty,
+            method=method,
+            device=device,
+        )
+
+        # Calculate the centre of the detector in pixel coordinates.
+        corners = np.concatenate([t.corners()[:, :2] for mod in self.modules for t in mod], axis=0)
+        min_x, min_y = corners.min(axis=0)
+        centre = np.array([-min_y / dy - 0.5, -min_x / dx - 0.5], dtype=np.float64)
+
+        # run distortion correction.
+        if dis_kwargs is None:
+            dis_kwargs = {}
+        flat = data_np.reshape((-1, nmod, mod_ss, mod_fs))
+        img0 = flat[0].reshape((nmod * mod_ss, mod_fs))
+        out0 = dis.correct(img0, **dis_kwargs)
+        out_flat = np.empty((flat.shape[0],) + out0.shape, dtype=out0.dtype)
+        out_flat[0] = out0
+        for i in range(1, flat.shape[0]):
+            img2d = flat[i].reshape((nmod * mod_ss, mod_fs))
+            out_flat[i] = dis.correct(img2d, **dis_kwargs)
+        out = out_flat.reshape(extra_shape + out0.shape)
+
+        return out, centre
+
     def position_modules_symmetric(self, data, out=None, threadpool=None):
         """Assemble data with the centre in the middle of the output array.
 
@@ -658,7 +818,7 @@ class DetectorGeometryBase:
 
         return distortion
 
-    def to_pyfai_detector(self):
+    def to_pyfai_detector(self, **kwargs):
         """Make a PyFAI detector object for this detector
 
         You can use PyFAI to azimuthally integrate detector images around
@@ -669,7 +829,7 @@ class DetectorGeometryBase:
             raise NotImplementedError
 
         from . import pyfai
-        det = getattr(pyfai, self._pyfai_cls_name)()
+        det = getattr(pyfai, self._pyfai_cls_name)(**kwargs)
         det.set_pixel_corners(self.to_distortion_array(allow_negative_xy=True))
         return det
 

--- a/extra_geom/base.py
+++ b/extra_geom/base.py
@@ -7,7 +7,7 @@ import numpy as np
 from .crystfel_fmt import write_crystfel_geom
 from .motors import read_motors_from_geom
 from .snapped import (GridGeometryFragment, SnappedGeometry,
-                      isinstance_no_import)
+                      _plot_data, isinstance_no_import)
 
 
 class GeometryFragment:
@@ -701,10 +701,12 @@ class DetectorGeometryBase:
                   ax=None,
                   figsize=None,
                   colorbar=True,
+                  interpolate=False,
                   **kwargs):
         """Plot data from the detector using this geometry.
 
-        This approximates the geometry to align all pixels to a 2D grid.
+        This approximates or interpolate (with interpolate=True) the geometry to
+        align all pixels to a 2D grid.
 
         Returns a matplotlib axes object.
 
@@ -731,9 +733,25 @@ class DetectorGeometryBase:
         colorbar : bool, dict
           Draw colobar with default values (if boolean is given). Colorbar
           appearance can be controlled by passing a dictionary of properties.
+        interpolate : bool
+          If True, use interpolation when drawing the image.
         kwargs :
           Additional keyword arguments passed to `~matplotlib.imshow`
         """
+        if interpolate:
+            res, centre = self.position_modules_interpolate(data)
+            return _plot_data(
+                res,
+                centre,
+                self,
+                axis_units=axis_units,
+                frontview=frontview,
+                ax=ax,
+                figsize=figsize,
+                colorbar=colorbar,
+                **kwargs,
+            )
+
         return self._snapped().plot_data(
             data, axis_units=axis_units, frontview=frontview, figsize=figsize,
             ax=ax, colorbar=colorbar, **kwargs

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -320,68 +320,6 @@ class AGIPD_1MGeometry(DetectorGeometryBase):
         ax.set_title('AGIPD-1M detector geometry ({})'.format(self.filename))
         return ax
 
-    def position_modules_interpolate(self, data):
-        """Assemble data from this detector according to where the pixels are.
-
-        This performs interpolation, which is very slow.
-        Use :meth:`position_modules` to get a pixel-aligned approximation
-        of the geometry.
-
-        Parameters
-        ----------
-
-        data : ndarray
-          The three dimensions should be channelno, pixel_ss, pixel_fs
-          (lengths 16, 512, 128). ss/fs are slow-scan and fast-scan.
-
-        Returns
-        -------
-        out : ndarray
-          Array with the one dimension fewer than the input.
-          The last two dimensions represent pixel y and x in the detector space.
-        centre : ndarray
-          (y, x) pixel location of the detector centre in this geometry.
-        """
-        from scipy.ndimage import affine_transform
-        assert data.shape == (16, 512, 128)
-        size_yx, centre = self._get_dimensions()
-        tmp = np.empty((16 * 8,) + size_yx, dtype=data.dtype)
-
-        for i, (module, mod_data) in enumerate(zip(self.modules, data)):
-            tiles_data = np.split(mod_data, 8)
-            for j, (tile, tile_data) in enumerate(zip(module, tiles_data)):
-                # We store (x, y, z), but numpy indexing, and hence affine_transform,
-                # work like [y, x]. Rearrange the numbers:
-                fs_vec_yx = tile.fs_vec[:2][::-1]
-                ss_vec_yx = tile.ss_vec[:2][::-1]
-
-                # Offset by centre to make all coordinates positive
-                corner_pos_yx = tile.corner_pos[:2][::-1] + centre
-
-                # Make the rotation matrix
-                rotn = np.stack((ss_vec_yx, fs_vec_yx), axis=-1)
-
-                # affine_transform takes a mapping from *output* to *input*.
-                # So we reverse the forward transformation.
-                transform = np.linalg.inv(rotn)
-                offset = np.dot(rotn, corner_pos_yx)  # this seems to work, but is it right?
-
-                affine_transform(
-                    tile_data,
-                    transform,
-                    offset=offset,
-                    cval=np.nan,
-                    output_shape=size_yx,
-                    output=tmp[i * 8 + j],
-                )
-
-        # Silence warnings about nans - we expect gaps in the result
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=RuntimeWarning)
-            out = np.nanmax(tmp, axis=0)
-
-        return out, centre
-
     def _get_dimensions(self):
         """Calculate appropriate array dimensions for assembling data.
 

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -1115,7 +1115,7 @@ class LPD_MiniGeometry(LPDGeometryBase):
         tileno, tile_fs = np.divmod(fast_scan, cls.frag_fs_pixels)
         return tileno.astype(np.int16), slow_scan, tile_fs
 
-    def to_pyfai_detector(self):
+    def to_pyfai_detector(self, **kwargs):
         """Make a PyFAI detector object for JUNGFRAU detector.
 
         You can use PyFAI to azimuthally integrate detector images around
@@ -1123,7 +1123,7 @@ class LPD_MiniGeometry(LPDGeometryBase):
         positions of all the pixels. See the examples for how to use this.
         """
         from . import pyfai
-        det = getattr(pyfai, self._pyfai_cls_name)(n_modules=self.n_modules)
+        det = getattr(pyfai, self._pyfai_cls_name)(n_modules=self.n_modules, **kwargs)
         det.set_pixel_corners(self.to_distortion_array(allow_negative_xy=True))
         return det
 
@@ -2019,7 +2019,7 @@ class JUNGFRAUGeometry(DetectorGeometryBase):
             data['module'] = data['module'] - 1
         return super().position_modules_interpolate(data, **kwargs)
 
-    def to_pyfai_detector(self):
+    def to_pyfai_detector(self, **kwargs):
         """Make a PyFAI detector object for JUNGFRAU detector.
 
         You can use PyFAI to azimuthally integrate detector images around
@@ -2027,7 +2027,7 @@ class JUNGFRAUGeometry(DetectorGeometryBase):
         positions of all the pixels. See the examples for how to use this.
         """
         from . import pyfai
-        det = getattr(pyfai, self._pyfai_cls_name)(n_modules=self.n_modules)
+        det = getattr(pyfai, self._pyfai_cls_name)(n_modules=self.n_modules, **kwargs)
         det.set_pixel_corners(self.to_distortion_array(allow_negative_xy=True))
         return det
 

--- a/extra_geom/detectors.py
+++ b/extra_geom/detectors.py
@@ -2011,6 +2011,14 @@ class JUNGFRAUGeometry(DetectorGeometryBase):
             data['module'] = data['module'] - 1
         return super().position_modules(data, out=out, threadpool=threadpool)
 
+    def position_modules_interpolate(self, data, **kwargs):
+        data = self._ensure_shape(data)
+        if isinstance_no_import(data, 'xarray', 'DataArray'):
+            # JUNGFRAU labels modules starting from 1; EXtra-geom uses 0-based.
+            data = data.copy(deep=False)
+            data['module'] = data['module'] - 1
+        return super().position_modules_interpolate(data, **kwargs)
+
     def to_pyfai_detector(self):
         """Make a PyFAI detector object for JUNGFRAU detector.
 
@@ -2044,6 +2052,7 @@ class PNCCDGeometry(DetectorGeometryBase):
     n_modules = 2
     n_tiles_per_module = 1
     expected_data_shape = (2, 512, 1024)
+    _pyfai_cls_name = 'PNCCD1MP'
 
     # Each module has a rectangular cutout around the intended beam
     # position, i.e. at the bottom center of the top module (towards
@@ -2169,6 +2178,11 @@ class PNCCDGeometry(DetectorGeometryBase):
     def position_modules(self, data, *args, **kwargs):
         return super().position_modules(self._ensure_shape(data),
                                         *args, **kwargs)
+
+    def position_modules_interpolate(self, data, *args, **kwargs):
+        return super().position_modules_interpolate(
+            self._ensure_shape(data), *args, **kwargs
+        )
 
     def plot_data(self, data, *args, **kwargs):
         return super().plot_data(self._ensure_shape(data),
@@ -2425,6 +2439,11 @@ class EpixGeometryBase(DetectorGeometryBase):
         return super().position_modules(self._ensure_shape(data),
                                         *args, **kwargs)
 
+    def position_modules_interpolate(self, data, *args, **kwargs):
+        return super().position_modules_interpolate(
+            self._ensure_shape(data), *args, **kwargs
+        )
+
     def plot_data(self, data, *args, **kwargs):
         return super().plot_data(self._ensure_shape(data),
                                  *args, **kwargs)
@@ -2469,6 +2488,7 @@ class Epix100Geometry(EpixGeometryBase):
         2 * frag_ss_pixels,
         2 * frag_fs_pixels
     )
+    _pyfai_cls_name = 'Epix100'
 
     @classmethod
     def from_relative_positions(cls, asic_gap=None, unit=None, top=(0., 0., 0.),
@@ -2546,6 +2566,7 @@ class Epix10KGeometry(EpixGeometryBase):
         2 * frag_ss_pixels,
         2 * frag_fs_pixels
     )
+    _pyfai_cls_name = 'Epix10K'
 
     @classmethod
     def example(cls):

--- a/extra_geom/pyfai.py
+++ b/extra_geom/pyfai.py
@@ -60,3 +60,30 @@ class JUNGFRAU_EuXFEL(Detector):
     def __init__(self, pixel1=7.5e-5, pixel2=7.5e-5, n_modules=1, **kwargs):
         self.MAX_SHAPE = max_shape = (n_modules*512, 1024)
         super().__init__(pixel1, pixel2, max_shape=max_shape, **kwargs)
+
+
+class PNCCD1MP(Detector):
+    IS_CONTIGUOUS = False
+    MAX_SHAPE = (2*512, 1024)
+    aliases = ["PNCCD 1MP"]
+
+    def __init__(self, pixel1=75e-6, pixel2=75e-6, **kwargs):
+        super().__init__(pixel1, pixel2, **kwargs)
+
+
+class Epix100(Detector):
+    IS_CONTIGUOUS = False
+    MAX_SHAPE = (2*352, 2*384)
+    aliases = ["ePix 100"]
+
+    def __init__(self, pixel1=50e-6, pixel2=50e-6, **kwargs):
+        super().__init__(pixel1, pixel2, **kwargs)
+
+
+class Epix10K(Detector):
+    IS_CONTIGUOUS = False
+    MAX_SHAPE = (2*176, 2*192)
+    aliases = ["ePix 10K"]
+
+    def __init__(self, pixel1=100e-6, pixel2=100e-6, **kwargs):
+        super().__init__(pixel1, pixel2, **kwargs)

--- a/extra_geom/snapped.py
+++ b/extra_geom/snapped.py
@@ -11,6 +11,65 @@ from itertools import chain
 import numpy as np
 
 
+def _plot_data(
+    image,
+    centre,
+    geom,
+    *,
+    axis_units='px',
+    frontview=True,
+    ax=None,
+    figsize=None,
+    colorbar=False,
+    **kwargs,
+):
+    import matplotlib.pyplot as plt
+    from matplotlib.cm import viridis
+
+    if axis_units not in {'px', 'm'}:
+        raise ValueError("axis_units must be 'px' or 'm', not {!r}"
+                         .format(axis_units))
+
+    min_y, min_x = -centre
+    max_y, max_x = np.array(image.shape) - centre
+
+    _extent = np.array((min_x - 0.5, max_x + 0.5, min_y - 0.5, max_y + 0.5))
+    cross_size = 20
+    if axis_units == 'm':
+        _extent[:2] *= geom._pixel_shape[0]  # x
+        _extent[2:] *= geom._pixel_shape[1]  # y
+        cross_size *= geom.pixel_size
+
+    # Use a dark grey for missing data
+    _cmap = copy(viridis)
+    _cmap.set_bad('0.25', 1.0)
+
+    kwargs.setdefault('cmap', _cmap)
+    kwargs.setdefault('extent', _extent)
+    kwargs.setdefault('origin', 'lower')
+
+    if ax is None:
+        fig = plt.figure(figsize=figsize or (10, 10))
+        ax = fig.add_subplot(1, 1, 1)
+
+    im = ax.imshow(image, **kwargs)
+    if isinstance(colorbar, dict) or colorbar is True:
+        if isinstance(colorbar, bool):
+            colorbar = {}
+        plt.colorbar(im, ax=ax, **colorbar)
+
+    ax.set_xlabel('metres' if axis_units == 'm' else 'pixels')
+    ax.set_ylabel('metres' if axis_units == 'm' else 'pixels')
+
+    if frontview:
+        ax.invert_xaxis()
+
+    # Draw a cross at the centre
+    ax.hlines(0, -cross_size, +cross_size, colors='w', linewidths=1)
+    ax.vlines(0, -cross_size, +cross_size, colors='w', linewidths=1)
+    return ax
+
+
 class GridGeometryFragment:
     """Holds the 2D axis-aligned position and orientation of one detector tile.
 
@@ -205,52 +264,18 @@ class SnappedGeometry:
                   **kwargs):
         """Implementation for plot_data_fast
         """
-        import matplotlib.pyplot as plt
-        from matplotlib.cm import viridis
-
-        if axis_units not in {'px', 'm'}:
-            raise ValueError("axis_units must be 'px' or 'm', not {!r}"
-                             .format(axis_units))
-
         res, centre = self.position_modules(modules_data)
-        min_y, min_x = -centre
-        max_y, max_x = np.array(res.shape) - centre
-
-        _extent = np.array((min_x - 0.5, max_x + 0.5, min_y - 0.5, max_y + 0.5))
-        cross_size = 20
-        if axis_units == 'm':
-            _extent[:2] *= self.geom._pixel_shape[0]  # x
-            _extent[2:] *= self.geom._pixel_shape[1]  # y
-            cross_size *= self.geom.pixel_size
-
-        # Use a dark grey for missing data
-        _cmap = copy(viridis)
-        _cmap.set_bad('0.25', 1.0)
-
-        kwargs.setdefault('cmap', _cmap)
-        kwargs.setdefault('extent', _extent)
-        kwargs.setdefault('origin', 'lower')
-
-        if ax is None:
-            fig = plt.figure(figsize=figsize or (10, 10))
-            ax = fig.add_subplot(1, 1, 1)
-
-        im = ax.imshow(res, **kwargs)
-        if isinstance(colorbar, dict) or colorbar is True:
-            if isinstance(colorbar, bool):
-                colorbar = {}
-            plt.colorbar(im, ax=ax, **colorbar)
-
-        ax.set_xlabel('metres' if axis_units == 'm' else 'pixels')
-        ax.set_ylabel('metres' if axis_units == 'm' else 'pixels')
-
-        if frontview:
-            ax.invert_xaxis()
-
-        # Draw a cross at the centre
-        ax.hlines(0, -cross_size, +cross_size, colors='w', linewidths=1)
-        ax.vlines(0, -cross_size, +cross_size, colors='w', linewidths=1)
-        return ax
+        return _plot_data(
+            res,
+            centre,
+            self.geom,
+            axis_units=axis_units,
+            frontview=frontview,
+            ax=ax,
+            figsize=figsize,
+            colorbar=colorbar,
+            **kwargs,
+        )
 
 
 def isinstance_no_import(obj, mod: str, cls: str):

--- a/extra_geom/tests/test_interpolate_assembly.py
+++ b/extra_geom/tests/test_interpolate_assembly.py
@@ -4,13 +4,31 @@ import xarray as xr
 
 pyFAI = pytest.importorskip("pyFAI")
 
-from extra_geom import AGIPD_500K2GGeometry
+from extra_geom import AGIPD_500K2GGeometry, LPD_1MGeometry, DSSC_1MGeometry, AGIPD_1MGeometry
 
 
-def test_position_modules_interpolate_conserves_signal_and_area():
-    geom = AGIPD_500K2GGeometry.example()
+def sample_data(geom, as_xarray=False):
     rng = np.random.default_rng(0)
-    data = rng.poisson(3, size=geom.expected_data_shape).astype(np.float32)
+    data = rng.poisson(2, size=(2, 2, *geom.expected_data_shape)).astype(np.float32)
+
+    if as_xarray:
+        data = xr.DataArray(
+            data,
+            dims=("train", "pulse", "module", "slow_scan", "fast_scan"),
+            coords={
+                "train": np.asarray([123456789, 123456790]),
+                "pulse": np.asarray([0, 1]),
+                "module": np.arange(geom.expected_data_shape[-3]),
+                "slow_scan": np.arange(geom.expected_data_shape[-2]),
+                "fast_scan": np.arange(geom.expected_data_shape[-1]),
+            },
+        )
+    return data
+
+
+def test_conserves_signal_and_area():
+    geom = AGIPD_500K2GGeometry.example()
+    data = sample_data(geom)
 
     out, _ = geom.position_modules_interpolate(data, resize=True)
 
@@ -18,23 +36,75 @@ def test_position_modules_interpolate_conserves_signal_and_area():
     assert np.isclose(np.nansum(out), data.sum(dtype=np.float64), rtol=1e-6, atol=1e-3)
 
 
-def test_position_modules_interpolate_oversample_preserves_total_signal():
+def test_oversample_preserves_total_signal():
     geom = AGIPD_500K2GGeometry.example()
-    rng = np.random.default_rng(1)
-    data = rng.poisson(2, size=geom.expected_data_shape).astype(np.float32)
-    da = xr.DataArray(
-        data[None, None, ...],
-        dims=("train", "pulse", "module", "slow_scan", "fast_scan"),
-        coords={
-            "train": np.asarray([123456789]),
-            "pulse": np.asarray([0]),
-            "module": np.arange(geom.expected_data_shape[-3]),
-            "slow_scan": np.arange(geom.expected_data_shape[-2]),
-            "fast_scan": np.arange(geom.expected_data_shape[-1]),
-        },
-    )
+    data = sample_data(geom, as_xarray=True)
 
-    out1, _ = geom.position_modules_interpolate(da, resize=True, oversample=1)
-    out2, _ = geom.position_modules_interpolate(da, resize=True, oversample=2)
+    with pytest.raises(ValueError, match='positive integer'):
+        geom.position_modules_interpolate(data, resize=True, oversample=0.5)
+
+    out1, _ = geom.position_modules_interpolate(data, resize=True, oversample=1)
+    out2, _ = geom.position_modules_interpolate(data, resize=True, oversample=2)
 
     assert np.isclose(np.nansum(out1), np.nansum(out2), rtol=1e-6, atol=1e-3)
+
+
+def test_output_pixel_size():
+    geom = LPD_1MGeometry.example()
+    data = sample_data(geom)
+
+    out1, _ = geom.position_modules_interpolate(data)
+    out2, _ = geom.position_modules_interpolate(data, output_pixel_size=geom.pixel_size * 2)
+    out3, _ = geom.position_modules_interpolate(data, output_pixel_size=(geom.pixel_size, geom.pixel_size))
+
+    assert out3.shape == out1.shape
+    assert out2.shape[:-2] == out1.shape[:-2]
+    assert out2.shape[-1] * 2 == out1.shape[-1]
+    assert out2.shape[-2] * 2 == out1.shape[-2]
+
+
+def test_xarray():
+    geom = LPD_1MGeometry.example()
+    data = sample_data(geom, as_xarray=True)
+
+    geom.position_modules_interpolate(data)
+
+    # bad module dim name
+    bad_mod_dim = data.rename({'module': 'mods'})
+    with pytest.raises(ValueError, match='module'):
+        geom.position_modules_interpolate(bad_mod_dim)
+
+    # bad module coordinates
+    bad_mod_coord = data.assign_coords(module=data.module + 1)
+    with pytest.raises(ValueError, match='module number labels should be in the range 0-15'):
+        geom.position_modules_interpolate(bad_mod_coord)
+
+    # bad data dimensions
+    coords = data.coords.copy()
+    coords['slow_scan'] = np.arange(512)
+    coords['fast_scan'] = np.arange(128)
+    bad_data_shape = xr.DataArray(
+        data.data.reshape(*data.shape[:-2], 512, 128),
+        dims=data.dims,
+        coords=coords,
+    )
+    with pytest.raises(ValueError, match='Wrong pixel dimensions for detector modules'):
+        geom.position_modules_interpolate(bad_data_shape)
+
+    # missing modules
+    missing_mods = data.isel(module=np.s_[:4])
+    geom.position_modules_interpolate(missing_mods)
+
+
+def test_hex_pixels():
+    geom = DSSC_1MGeometry.example()
+    data = sample_data(geom)
+
+    with pytest.raises(NotImplementedError, match='this geometry has 6 corners per pixel.'):
+        geom.position_modules_interpolate(data)
+
+
+def plot_smoke():
+    geom = AGIPD_1MGeometry.example()
+    data = sample_data(geom)
+    geom.plot_data(data[0, 0], interpolate=True)

--- a/extra_geom/tests/test_interpolate_assembly.py
+++ b/extra_geom/tests/test_interpolate_assembly.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import xarray as xr
 
 pyFAI = pytest.importorskip("pyFAI")
 
@@ -21,8 +22,19 @@ def test_position_modules_interpolate_oversample_preserves_total_signal():
     geom = AGIPD_500K2GGeometry.example()
     rng = np.random.default_rng(1)
     data = rng.poisson(2, size=geom.expected_data_shape).astype(np.float32)
+    da = xr.DataArray(
+        data[None, None, ...],
+        dims=("train", "pulse", "module", "slow_scan", "fast_scan"),
+        coords={
+            "train": np.asarray([123456789]),
+            "pulse": np.asarray([0]),
+            "module": np.arange(geom.expected_data_shape[-3]),
+            "slow_scan": np.arange(geom.expected_data_shape[-2]),
+            "fast_scan": np.arange(geom.expected_data_shape[-1]),
+        },
+    )
 
-    out1, _ = geom.position_modules_interpolate(data, resize=True, oversample=1)
-    out2, _ = geom.position_modules_interpolate(data, resize=True, oversample=2)
+    out1, _ = geom.position_modules_interpolate(da, resize=True, oversample=1)
+    out2, _ = geom.position_modules_interpolate(da, resize=True, oversample=2)
 
     assert np.isclose(np.nansum(out1), np.nansum(out2), rtol=1e-6, atol=1e-3)

--- a/extra_geom/tests/test_interpolate_assembly.py
+++ b/extra_geom/tests/test_interpolate_assembly.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+
+pyFAI = pytest.importorskip("pyFAI")
+
+from extra_geom import AGIPD_500K2GGeometry
+
+
+def test_position_modules_interpolate_conserves_signal_and_area():
+    geom = AGIPD_500K2GGeometry.example()
+    rng = np.random.default_rng(0)
+    data = rng.poisson(3, size=geom.expected_data_shape).astype(np.float32)
+
+    out, _ = geom.position_modules_interpolate(data, resize=True)
+
+    # Total signal should be conserved when resize=True.
+    assert np.isclose(np.nansum(out), data.sum(dtype=np.float64), rtol=1e-6, atol=1e-3)
+
+
+def test_position_modules_interpolate_oversample_preserves_total_signal():
+    geom = AGIPD_500K2GGeometry.example()
+    rng = np.random.default_rng(1)
+    data = rng.poisson(2, size=geom.expected_data_shape).astype(np.float32)
+
+    out1, _ = geom.position_modules_interpolate(data, resize=True, oversample=1)
+    out2, _ = geom.position_modules_interpolate(data, resize=True, oversample=2)
+
+    assert np.isclose(np.nansum(out1), np.nansum(out2), rtol=1e-6, atol=1e-3)

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(name="EXtra-geom",
           'numpy',
       ],
       extras_require={
-          'interpolate': ['scipy'],
+          'interpolate': ['pyFAI'],
           'docs': [
               'sphinx >=4.3',  # Minimum version for Python 3.10
               'nbsphinx',


### PR DESCRIPTION
Assemble data onto a regular grid using pixel-splitting.

This uses pyFAI's distortion correction machinery to produce an output image corrected from spatial distortion.

Snapped:
<img width="3083" height="1876" alt="snapped" src="https://github.com/user-attachments/assets/02e159cc-c53b-482b-bb3e-2c3744126a9a" />

Interpolated:
<img width="3079" height="1899" alt="interpolated" src="https://github.com/user-attachments/assets/72baf49d-6af0-4181-a4f1-ae7f02e138e4" />
