### PR TITLE
Default vmin & vmax for plotting based on the 2nd & 98th percentiles

### DIFF
--- a/extra_geom/snapped.py
+++ b/extra_geom/snapped.py
@@ -61,6 +61,7 @@ def _plot_data(
     if isinstance(colorbar, dict) or colorbar is True:
         if isinstance(colorbar, bool):
             colorbar = {}
+        colorbar.setdefault('fraction', 0.07)
         plt.colorbar(im, ax=ax, **colorbar)
 
     ax.set_xlabel('metres' if axis_units == 'm' else 'pixels')

--- a/extra_geom/snapped.py
+++ b/extra_geom/snapped.py
@@ -48,7 +48,7 @@ def _plot_data(
     kwargs.setdefault('extent', _extent)
     kwargs.setdefault('origin', 'lower')
 
-    if not ('vmin' in kwargs and 'vmax' in kwargs):
+    if ('norm' not in kwargs) and ('vmin' not in kwargs or 'vmax' not in kwargs):
         _low, _high = np.nanpercentile(image, [2., 98.])
         kwargs.setdefault('vmin', _low)
         kwargs.setdefault('vmax', _high)

--- a/extra_geom/snapped.py
+++ b/extra_geom/snapped.py
@@ -48,6 +48,11 @@ def _plot_data(
     kwargs.setdefault('extent', _extent)
     kwargs.setdefault('origin', 'lower')
 
+    if not ('vmin' in kwargs and 'vmax' in kwargs):
+        _low, _high = np.nanpercentile(image, [2., 98.])
+        kwargs.setdefault('vmin', _low)
+        kwargs.setdefault('vmax', _high)
+
     if ax is None:
         fig = plt.figure(figsize=figsize or (10, 10))
         ax = fig.add_subplot(1, 1, 1)


### PR DESCRIPTION
Borrowing xarray's [robust plotting option](https://docs.xarray.dev/en/stable/user-guide/plotting.html#robust-plotting), but turning it on by default because detector images often have a few outliers which tends to wash out the default scale.

While I was playing with the plots, I also found the default colour bar unnecessarily large, so I've reduced the fraction matplotlib tries to take for this from 0.15 to 0.07.

Before:

<img width="911" height="829" alt="image" src="https://github.com/user-attachments/assets/35a02cb1-82d8-4da1-9566-2d61c51f0d7f" />

After:

<img width="967" height="850" alt="image" src="https://github.com/user-attachments/assets/aff57271-2ef0-488d-9a49-a5243303e73e" />