### PR TITLE
add link to AGIPD paper for more information.

### DIFF
--- a/docs/agipd_geometry.ipynb
+++ b/docs/agipd_geometry.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "#  AGIPD-1M Geometry\n",
     "\n",
-    "The AGIPD-1M detector, which is used at the SPB & MID experiments, consists of 16 modules of 512×128 pixels each. Each module is further divided into 16 ASICs, but these are arranged in pairs, so we treat a module as 8 tiles.\n",
+    "The [AGIPD-1M detector](https://doi.org/10.1107/S1600577518016077), which is used at the SPB & MID experiments, consists of 16 modules of 512×128 pixels each. Each module is further divided into 16 ASICs, but these are arranged in pairs, so we treat a module as 8 tiles.\n",
     "\n",
     "To view or analyse detector data, we need to apply geometry to find the positions of pixels."
    ]


### PR DESCRIPTION
Simply adds a link in the AGIPD documentation to a open access paper titled
"The Adaptive Gain Integrating Pixel Detector at the European XFEL"
which contains more details on AGIPD.