### PR TITLE
Only bump Github actions versions on major version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,8 @@ updates:
       actions:
         patterns:
           - "*"
+    # We currently only specify a major version of actions (e.g. actions/checkout@v6)
+    # So we only want to change it when the major version changes.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]


### PR DESCRIPTION
I hope this will stop it trying to 'update' v6 to v6.0.2 when 6.0.3 is tagged.